### PR TITLE
Add progress bar, queue preview, and weighted shuffle tracking

### DIFF
--- a/.claude/plans/task-002-add-progress-bar.md
+++ b/.claude/plans/task-002-add-progress-bar.md
@@ -1,0 +1,126 @@
+# Progress Bar Feature Plan
+
+## Context
+Add a visual progress bar showing how much time remains before the next photo appears.
+Rendered as a thin horizontal bar at the top or bottom edge of the screen. The bar fills
+left-to-right from 0% (new photo just appeared) to 100% (next photo about to load).
+Height, color, and position are configurable.
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `picframe/src/picframe/model.py` | Add 4 keys to `DEFAULT_CONFIG['viewer']` |
+| `picframe/src/picframe/config/configuration_example.yaml` | Document the 4 new keys in `viewer:` section |
+| `picframe/src/picframe/viewer_display.py` | Init vars, new `__make_solid_bar` helper, new `__draw_progress_bar`, call-site in `slideshow_is_running` |
+
+---
+
+## Config Keys (add to DEFAULT_CONFIG viewer + configuration_example.yaml)
+
+```python
+'show_progress_bar':    False,
+'progress_bar_height':  8,                    # pixels tall
+'progress_bar_color':   [255, 255, 255, 200], # RGBA
+'progress_bar_position':'B',                  # 'T' top / 'B' bottom
+```
+
+No background track — just a single bar growing left-to-right from 0 to full screen width.
+
+---
+
+## viewer_display.py Changes
+
+### 1. `__init__` — read config & init state (after sensors block, same comment style)
+
+```python
+# [ivan] progress bar configs
+self.__show_progress_bar    = config['show_progress_bar']
+self.__progress_bar_height  = config['progress_bar_height']
+self.__progress_bar_color   = config['progress_bar_color']
+self.__progress_bar_position= config['progress_bar_position']
+self.__progress_bar_tex     = None  # 1x1 color texture, created once on first draw
+self.__progress_bar_fill    = None  # sprite rebuilt when progress crosses 0.5% step
+self.__prev_progress        = -1.0
+```
+
+### 2. `slideshow_start` — no setup needed (bar sprite is created lazily in `__draw_progress_bar`)
+
+### 3. New private helper `__make_solid_bar(w, h, x)` (place near `__draw_overlay`)
+
+Creates a pi3d.Sprite from a cached 1×1 RGBA texture (same texture pattern as text_bkg in `slideshow_start`).
+The texture is created once on first call and reused — only the sprite geometry changes per rebuild.
+
+```python
+def __make_solid_bar(self, w, h, x):
+    if self.__progress_bar_tex is None:
+        r, g, b, a = self.__progress_bar_color
+        tex_arr = np.zeros((1, 1, 4), dtype=np.uint8)
+        tex_arr[0, 0] = [r, g, b, a]
+        self.__progress_bar_tex = pi3d.Texture(tex_arr, blend=True, mipmap=False, free_after_load=True)
+    bar_y = (self.__display.height - h) // 2
+    if self.__progress_bar_position == "B":
+        bar_y *= -1
+    sprite = pi3d.Sprite(w=w, h=h, x=x, y=bar_y, z=3.9)
+    sprite.set_draw_details(self.__flat_shader, [self.__progress_bar_tex])
+    return sprite
+```
+
+Z=3.9 renders in front of text_bkg (z=4.0) and overlay (z=4.1), behind clock/sensors (z=0.1).
+Lower z = closer to camera in pi3d's 2D mode. Main image is at z=5.0 (furthest back).
+
+### 4. New private method `__draw_progress_bar(time_delay)` (place after `__draw_overlay`)
+
+```python
+def __draw_progress_bar(self, time_delay):
+    if self.__next_tm == 0.0:
+        return
+    tm = time.time()
+    progress = max(0.0, min(1.0, 1.0 - (self.__next_tm - tm) / time_delay)) if time_delay > 0 else 0.0
+    quantized = round(progress * 200) / 200.0  # 0.5% steps — avoids VBO rebuild every frame at 20fps
+
+    if quantized != self.__prev_progress:
+        bar_w = max(1, int(self.__display.width * quantized))
+        x = bar_w // 2 - self.__display.width // 2   # keep left edge flush to screen left
+        self.__progress_bar_fill = self.__make_solid_bar(
+            w=bar_w, h=self.__progress_bar_height, x=x)
+        self.__prev_progress = quantized
+
+    if self.__progress_bar_fill:
+        self.__progress_bar_fill.draw()
+```
+
+### 5. Call-site in `slideshow_is_running` (after `__draw_overlay`, line ~885)
+
+```python
+self.__slide.draw()
+self.__draw_overlay()
+if self.__show_progress_bar:          # NEW
+    self.__draw_progress_bar(time_delay)
+if self.clock_is_on:
+    self.__draw_clock()
+```
+
+---
+
+## Key Reused Patterns
+
+- **1×1 numpy texture → pi3d.Sprite** — same as `text_bkg` in `slideshow_start` (line 719-724)
+- **Cached texture** — color texture created once, reused across all ~200 sprite rebuilds per image
+- **Lazy rebuild on 0.5% step** — same guard pattern as `__draw_clock` (rebuild only when value changes)
+- **Z-depth layering** — z=3.9 renders in front of overlays, behind clock/sensors/text
+- **`self.__next_tm` timing** — already maintained in `slideshow_is_running` (set at line 814)
+- **Config comment style** — `# [ivan]` prefix block, matching sensors block in `__init__`
+- **No background track** — single growing bar only
+
+---
+
+## Verification
+
+1. Set `show_progress_bar: True` in `configuration.yaml`
+2. Run `python -m picframe.start`
+3. Observe a thin bar at top/bottom growing left-to-right over `time_delay` seconds
+4. Try `progress_bar_height: 20`, `progress_bar_position: "T"`, custom RGBA colors — verify each
+5. Confirm bar is absent when `show_progress_bar: False` (default)

--- a/.claude/plans/task-003-add-better-shuffle-logic.md
+++ b/.claude/plans/task-003-add-better-shuffle-logic.md
@@ -1,0 +1,404 @@
+# Task 003: Add Better Shuffle Logic
+
+## Context
+
+The current shuffle behavior in this fork is no longer pure random.
+
+At the moment, when `model.shuffle` is enabled, the playlist is rebuilt by sorting on:
+
+```sql
+displayed_count ASC, RANDOM()
+```
+
+This behavior was introduced to stop the slideshow from repeatedly favoring a subset of photos after restarts or partial runs. It improves fairness, but it is still a deterministic bucketed sort:
+
+- all photos with `displayed_count = 0` are shown before any photo with `displayed_count = 1`
+- all photos with `displayed_count = 1` are shown before any photo with `displayed_count = 2`
+- randomness only exists inside each count bucket
+
+This solves underexposure of some photos, but it does not feel like true random playback. It also does not directly help rediscover older photos, because `displayed_count` measures exposure rather than age.
+
+The goal of this task is to replace the current bucketed shuffle with a **weighted random shuffle** that:
+
+- still favors photos that have been shown less often
+- gives older photos a modest boost
+- keeps all photos eligible
+- remains simple and maintainable
+- preserves the existing playlist lifecycle and existing `portrait_pairs` behavior
+
+---
+
+## Current Behavior Summary
+
+### Current playlist lifecycle
+
+The playlist is **not** rebuilt on every photo selection.
+
+It is rebuilt only when the model reloads files, which happens on startup and later on reshuffle/reload conditions already implemented in `Model`.
+
+That means:
+
+- a playlist is generated once
+- the slideshow consumes that playlist in order
+- `displayed_count` is updated as photos are shown
+- the updated counts do **not** change the remaining order inside the already-built playlist
+- a new playlist is built only on the next reload
+
+This lifecycle must remain unchanged for this task.
+
+### Current shuffle behavior
+
+Current shuffle behavior lives in `Model.__get_files()` and relies on SQL ordering through `ImageCache.query_cache()`.
+
+When `shuffle=True`:
+
+- the model builds a sort expression using `displayed_count ASC, RANDOM()`
+- SQLite returns a fully ordered list of file ids
+- that list becomes the current playlist
+
+### Current `recent_n` behavior
+
+`recent_n` is an existing feature that biases more recent files to the front of the shuffled order.
+
+This task must preserve that behavior semantically:
+
+- recent files should still be shown before older files
+- but within each recent/older partition, ordering should use the new weighted random logic rather than the old count-bucket sort
+
+### Current `portrait_pairs` behavior
+
+When `portrait_pairs=False`, each playlist entry is a single file id.
+
+When `portrait_pairs=True`, the existing cache logic creates a list where:
+
+- landscape-capable slots remain single items
+- portrait items can be paired into `(file_id_1, file_id_2)` tuples
+
+This task must preserve that public behavior. The slideshow should still receive the same shape of playlist output that it expects today.
+
+---
+
+## Problem Statement
+
+The current `displayed_count ASC, RANDOM()` approach has three important drawbacks:
+
+1. It is not genuinely random.
+   The slideshow progresses through count buckets in order, which can feel like a soft cycle rather than natural randomness.
+
+2. It does not directly surface older photos.
+   A recently imported photo with `displayed_count = 0` outranks an old neglected photo with `displayed_count = 1`, even if the product goal is to rediscover older photos.
+
+3. It becomes awkward around portrait pairing if shuffle behavior is built from multiple independent orderings.
+   If portraits are reshuffled separately from the global order, the actual playback order can drift away from the intended weighting policy.
+
+This task should resolve all three while staying small and readable.
+
+---
+
+## Desired End State
+
+### High-level behavior
+
+When `shuffle=True`, the playlist should be built using **weighted random sampling without replacement**.
+
+Every candidate photo stays eligible, but its probability of appearing earlier in the playlist should increase when:
+
+- its `displayed_count` is lower
+- its `last_modified` timestamp is older
+
+This must produce a playlist that is:
+
+- random
+- biased toward under-shown photos
+- modestly biased toward older photos
+- still capable of showing frequently shown or recent photos
+
+### Explicit non-goals
+
+This task must **not**:
+
+- add a new config key or mode selector
+- add a new HTTP control
+- change the schema
+- change how `displayed_count` is stored or updated
+- rebuild the playlist after every shown photo
+- redesign `portrait_pairs`
+
+The only intended user-visible change is the quality of the shuffle behavior when `shuffle=True`.
+
+---
+
+## Implementation Strategy
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/picframe/model.py` | Route the shuffle path away from SQL `ORDER BY` and into a dedicated weighted-shuffle query path |
+| `src/picframe/image_cache.py` | Add the weighted shuffle helper logic and a cache query method that returns playlist entries in the new weighted order |
+| `src/picframe/config/configuration_example.yaml` | Update the `shuffle` comment to describe the new behavior |
+| `test/` | Add targeted tests for the weighted shuffle helper and the portrait-pair consistency behavior |
+
+---
+
+## Detailed Design
+
+### 1. Keep the current playlist lifecycle
+
+Do not change when the playlist is rebuilt.
+
+The new algorithm must still run only when the playlist is reloaded:
+
+- on startup
+- when reshuffle conditions are met
+- when existing config/filter/file-reload behavior triggers a reload
+
+The output of the new logic should still be assigned into `self.__file_list`, and the rest of the model should continue to consume that list exactly as it does now.
+
+### 2. Move shuffle ordering out of SQL `ORDER BY`
+
+The existing SQL ordering is too limited for this feature because:
+
+- weighted shuffle is easier to express correctly in Python
+- keeping portrait-pair behavior consistent is easier if one in-memory order becomes the single source of truth
+
+Therefore:
+
+- keep `ImageCache.query_cache()` unchanged for non-shuffle mode
+- add a separate shuffle path in `ImageCache`, for example `query_cache_shuffle(...)`
+- in `Model.__get_files()`, call the new shuffle method only when `self.shuffle` is true
+
+Non-shuffle behavior must remain unchanged.
+
+### 3. Candidate data required for weighted shuffle
+
+The weighted shuffle path must fetch enough data from `all_data` to compute ordering in memory.
+
+At minimum, each candidate row needs:
+
+- `file_id`
+- `displayed_count`
+- `last_modified`
+- `is_portrait`
+
+No schema change is required because these fields already exist in the current DB/view setup.
+
+### 4. Weighting rules
+
+Use fixed internal coefficients in v1. Do not add configuration.
+
+Recommended formulas:
+
+```text
+count_weight = 1 / (displayed_count + 1) ^ 1.5
+```
+
+This keeps never-shown photos strongly favored while still leaving higher-count photos eligible.
+
+Age should be a bounded secondary signal:
+
+```text
+age_weight = 1.0 + age_bonus
+```
+
+Where:
+
+- `age_bonus` is normalized within the current partition only
+- `age_bonus` stays in a narrow range, for example `0.0` to `0.3`
+- the oldest photo in the partition gets the highest bonus
+- the newest photo gets little or no bonus
+
+Final effective weight:
+
+```text
+total_weight = count_weight * age_weight
+```
+
+The age signal must remain weaker than the count signal. This task is about improved shuffle fairness, not about forcing a strict oldest-first slideshow.
+
+### 5. Weighted random ordering method
+
+Build a random permutation without replacement using the weights above.
+
+The recommended implementation is:
+
+- compute one random priority value per row from its weight
+- sort by that priority
+- return rows in that sorted order
+
+This provides:
+
+- randomness
+- a full playlist order
+- no repeated selection within one playlist
+- simple implementation with no repeated database queries
+
+Any mathematically equivalent weighted-without-replacement approach is acceptable, but the code should stay small and readable.
+
+### 6. Preserve `recent_n` semantics
+
+The current meaning of `recent_n` must be kept.
+
+Implementation rule:
+
+- split the candidate rows into two partitions using the existing recent cutoff
+- partition A: recent rows
+- partition B: older rows
+- run the weighted shuffle independently inside each partition
+- concatenate the results as:
+
+```text
+recent partition first + older partition second
+```
+
+This preserves the current “recent first” behavior while improving the randomness inside each partition.
+
+### 7. Preserve `portrait_pairs` while keeping shuffle logic consistent
+
+This is the most important design constraint.
+
+The implementation must not compute one weighted order for all photos and then independently reshuffle portrait photos a second time. Doing so breaks consistency, because portrait photos would no longer be shown according to the same global weighted priorities as landscape photos.
+
+The correct rule is:
+
+- compute **one** weighted order across the full candidate set exactly once
+- use that order as the single source of truth
+- if `portrait_pairs=False`, convert it directly into single-item playlist tuples
+- if `portrait_pairs=True`, reuse the existing portrait-slot packing behavior, but derive it from the already ordered rows
+
+Concretely:
+
+1. Build `ordered_rows = weighted_shuffle_rows(all_rows, recent_cutoff=...)`
+2. Derive the landscape/portrait slot layout from `ordered_rows`
+3. Build the portrait fill list by extracting portrait rows from `ordered_rows` in the same order they already appear
+4. Reuse the current pairing loop to produce the final playlist tuples
+
+This guarantees:
+
+- portraits and landscapes compete in the same global weighted shuffle
+- portraits are paired in an order consistent with the single global shuffle
+- existing playlist shape remains unchanged
+
+### 8. Readability constraints
+
+Keep the implementation intentionally modest.
+
+Preferred structure:
+
+- one small helper to read nullable row values safely, if needed
+- one helper to weighted-shuffle a single partition
+- one helper to apply recent partitioning
+- one `ImageCache` method that returns final playlist tuples for shuffle mode
+
+Avoid:
+
+- introducing strategy classes
+- adding config tuning parameters
+- duplicating the portrait-pair packing algorithm in multiple places
+- large abstractions that are harder to understand than the current code
+
+Target outcome: another engineer should be able to read the shuffle path in one pass and understand it.
+
+---
+
+## Public / Behavioral Contract
+
+After this task:
+
+- `shuffle=False` continues to use the existing non-random SQL sort path
+- `shuffle=True` means:
+  - random playlist order
+  - less-shown photos are favored
+  - older photos are modestly favored
+  - recent photos still appear before older ones when `recent_n > 0`
+- `portrait_pairs` continues to work exactly as a consumer-facing feature
+- no config migration is required
+
+Update the config comment for `shuffle` so the documented behavior matches the code.
+
+---
+
+## Suggested Test Coverage
+
+### Unit-level shuffle tests
+
+Add tests around the pure weighted-shuffle helper(s).
+
+Required scenarios:
+
+1. Lower `displayed_count` is favored over higher `displayed_count`
+2. Older photos are favored modestly when `displayed_count` is equal
+3. High-count photos remain eligible and are not filtered out
+4. Recent partition stays ahead of older partition when `recent_n` logic is applied
+
+These tests should validate statistical tendency, not exact ordering from a single run.
+
+### Production-path tests
+
+Add at least one test that covers the real shuffle playlist-construction path rather than only the pure helper.
+
+Required scenarios:
+
+1. `query_cache_shuffle()` returns single-item tuples when `portrait_pairs=False`
+2. `query_cache_shuffle()` returns valid tuple shapes when `portrait_pairs=True`
+3. Portrait ordering remains consistent with the single global weighted order
+
+The third test is critical. It should fail if portraits are independently reshuffled a second time.
+
+### Regression checks
+
+Add a simple regression test or inspection point for:
+
+- non-shuffle path unchanged
+- no schema change required
+- existing `displayed_count` update flow unchanged
+
+---
+
+## Manual Verification
+
+After implementation, perform a manual sanity check against a realistic mixed library.
+
+Construct or inspect a set that includes:
+
+- never-shown recent photos
+- never-shown old photos
+- frequently shown recent photos
+- frequently shown old photos
+- enough portrait photos to trigger `portrait_pairs`
+
+Manual expectations:
+
+1. Shuffle still looks random rather than grouped by exact count buckets
+2. Never-shown photos appear more often near the front, but not in a rigid “all zero-count first” block
+3. Older photos get a noticeable but modest boost
+4. Frequently shown photos still appear sometimes
+5. Portrait pairing still produces valid slideshow entries
+6. Rebuilding the playlist creates a different order while preserving the same bias profile
+
+---
+
+## Acceptance Criteria
+
+This task is complete when all of the following are true:
+
+- shuffle mode no longer relies on `displayed_count ASC, RANDOM()`
+- shuffle mode uses weighted random ordering based on `displayed_count` and `last_modified`
+- `recent_n` semantics are preserved
+- `portrait_pairs` behavior is preserved
+- portrait ordering is derived from one single global weighted order, not from a second portrait-only reshuffle
+- non-shuffle mode is unchanged
+- config/example documentation reflects the new meaning of `shuffle`
+- tests cover both the pure weighting logic and the real playlist-construction path
+
+---
+
+## Implementation Notes for the Assignee
+
+- Keep this as a behavioral refactor, not a feature expansion.
+- Prefer the smallest number of new helpers that still make the algorithm clear.
+- Do not add user-facing tuning knobs unless explicitly requested later.
+- Be careful not to accidentally change the semantics of `recent_n`.
+- Be careful not to introduce a second independent portrait shuffle.
+- If a helper is hard to test because of import-time runtime dependencies, extract only the minimum pure logic needed for isolated tests.
+

--- a/.claude/plans/task-004-add-images-queue-to-web-panel.md
+++ b/.claude/plans/task-004-add-images-queue-to-web-panel.md
@@ -1,0 +1,479 @@
+# Task 004: Add Images Queue To Web Panel
+
+## Context
+
+The current HTTP panel shows the active image preview and a set of control cards, but it does not expose the slideshow queue that the model already keeps in memory.
+
+This fork now builds a full playlist ahead of playback in `Model.__file_list`, which makes it possible to expose a queue preview in the web UI without changing slideshow semantics.
+
+The user wants two improvements:
+
+- a visible queue of upcoming images in the HTTP panel
+- clickable queue entries that jump playback directly to the selected slot
+
+The user also wants small image previews in the queue to make it easier to identify photos. Because the target device can be low-power hardware such as Raspberry Pi Zero class systems, the implementation must stay lightweight and must not block initial page load on thumbnail generation.
+
+---
+
+## Goals
+
+Add a queue panel to the HTTP UI that:
+
+- shows the current slot and a short preview of upcoming slots
+- allows clicking a queue item to jump directly to that slot
+- shows small thumbnail previews for queue items
+- loads quickly even on slow hardware
+- preserves the current slideshow lifecycle and weighted shuffle behavior
+- fits the existing HTTP server routing and auth flow
+
+---
+
+## Non-Goals
+
+This task must **not**:
+
+- redesign slideshow ordering logic
+- rebuild or reorder the queue when the user clicks a queued item
+- add drag-and-drop queue editing
+- add a full gallery browser of the entire library
+- generate thumbnails for the full playlist up front
+- add a frontend framework or heavy client-side state layer
+
+The queue click behavior may simply skip over intermediate entries.
+
+---
+
+## Desired User Experience
+
+When the user opens the web panel:
+
+- the main page should render quickly
+- a queue card should appear under or near the main image preview
+- the queue card should show a compact list of the next few slots
+- each slot should display:
+  - slot number
+  - filename or short label
+  - a small image preview
+  - a `pair` indicator when the slot contains a portrait pair
+- clicking a slot should make that slot the next item shown
+
+The user should not have to wait for thumbnail generation before the page itself becomes usable.
+
+---
+
+## Implementation Strategy
+
+## Files To Modify
+
+| File | Change |
+|------|--------|
+| `src/picframe/model.py` | Add read-only queue snapshot helpers and a slot-jump method |
+| `src/picframe/controller.py` | Expose queue snapshot and jump-to-slot actions to the HTTP layer |
+| `src/picframe/interface_http.py` | Add queue JSON endpoint and thumbnail endpoint; keep initial page render cheap |
+| `src/picframe/html/index.html` | Add queue card and queue markup placeholders |
+| `src/picframe/html/pf_functions.js` | Fetch queue data separately, render queue list, trigger jump requests, refresh thumbnails lazily |
+| `src/picframe/html/style.css` | Add lightweight queue card styles |
+| `test/` | Add focused tests for queue snapshot shape, jump behavior, and thumbnail endpoint behavior where practical |
+
+---
+
+## Detailed Design
+
+### 1. Keep queue ownership in `Model`
+
+The queue already exists in memory as `self.__file_list`.
+
+Add model-level helpers that expose queue data without leaking internal mutation details:
+
+- `get_queue_snapshot(limit=...)`
+- `set_next_file_index(index)` or equivalent slot-jump method
+
+The snapshot should be read-only and derived from the current playlist state.
+
+Recommended snapshot contents:
+
+- `displayed_index`
+- `next_index`
+- `total_slots`
+- `current_slot`
+- `upcoming_slots`
+
+Pointer semantics must be explicit:
+
+- `self.__file_index` points to the next slot to be read by `get_next_file()`
+- the currently displayed slot is therefore `self.__file_index - 1`
+- snapshot code must not report `self.__file_index` as the currently displayed slot
+
+Recommended rules:
+
+- `displayed_index` should be `None` before anything has been shown
+- `next_index` should be the slot that will be consumed by the next navigation event
+
+Each slot should preserve playlist semantics:
+
+- single image slot -> one file id
+- portrait pair slot -> two file ids
+
+To support the web panel, the snapshot should include lightweight labels such as:
+
+- `slot_index`
+- `file_ids`
+- `is_pair`
+- `primary_fname`
+- `secondary_fname` when relevant
+
+Avoid embedding image bytes or expensive metadata in this snapshot.
+
+Do not use `get_number_of_files()` for queue totals. That method counts files across tuple members and is wrong for queue slot counts when portrait pairs are enabled. Use `len(self.__file_list)` semantics for `total_slots`.
+
+### 2. Implement simple jump-to-slot behavior
+
+Jump behavior should stay intentionally small.
+
+When the user clicks a queue item:
+
+- set the model’s next slot pointer to that queue index
+- trigger the same immediate navigation path used by `next()`
+
+This means intermediate queue entries are skipped. That is acceptable and explicitly desired for this task.
+
+Important constraint:
+
+- jump by playlist slot index, not by `file_id`
+
+This preserves correct behavior for portrait-pair slots.
+
+Reload edge case:
+
+- if `self.__reload_files` is already true when a jump is requested, the next `get_next_file()` call will rebuild the playlist and reset the pointer
+- v1 should handle this explicitly rather than silently losing the jump target
+
+Recommended v1 behavior:
+
+- reject the jump request with a small status payload such as `{"ok": false, "reason": "reload_pending"}`
+- frontend should then refresh queue state and let the user try again after reload completes
+
+### 3. Expose queue state through the controller
+
+The HTTP server should not inspect model internals directly beyond the controller boundary.
+
+Add controller methods such as:
+
+- `get_queue_snapshot(limit=8)` or similar
+- `jump_to_queue_index(index)`
+
+`jump_to_queue_index()` should:
+
+- validate or delegate validation of the target index
+- set the next slot pointer
+- force immediate transition in the same way manual navigation does
+
+Important controller detail:
+
+- the controller method must mirror the relevant parts of `next()`
+- specifically it must set `self.__next_tm = 0` and `self.__force_navigate = True`
+
+Changing only the model pointer is not enough.
+
+### 4. Add dedicated HTTP endpoints
+
+Do not overload the generic `/?all` response with queue and thumbnail payloads.
+
+Important routing constraint:
+
+- the current `do_GET()` implementation only distinguishes between requests with and without `?`
+- path-only endpoints such as `/api/queue` will not work unless `do_GET()` is explicitly extended before the existing static-file branch
+
+Two valid implementation options:
+
+1. Extend `do_GET()` with explicit path-prefix routing before static file serving.
+2. Use query-string style endpoints that fit the current architecture, for example:
+   - `/?queue_snapshot=1`
+   - `/?queue_jump=5`
+   - `/?queue_thumb=5`
+
+Recommended default for minimal change:
+
+- keep query-style queue endpoints because they fit the existing server structure with less routing churn
+
+Queue operations should still remain logically separate from the generic setter polling path.
+
+All new queue and thumbnail routes must remain inside the existing `do_AUTHHEAD()` protection flow.
+
+Recommended behavior:
+
+- queue JSON endpoint returns only small structured metadata
+- thumbnail endpoint returns a small JPEG image for one slot
+- jump endpoint triggers the slot jump and returns a small success or failure JSON payload
+
+### 5. Keep page load non-blocking
+
+This is the most important performance rule.
+
+The initial HTML render must not synchronously generate queue thumbnails.
+
+Instead:
+
+- render the page shell immediately
+- fetch queue metadata separately
+- request thumbnails as independent image URLs
+
+That way:
+
+- the page becomes interactive immediately
+- slow thumbnail generation affects only individual queue images
+- the queue text can appear before the thumbnails finish loading
+
+### 6. Thumbnail generation strategy
+
+Thumbnail generation must be conservative and cache-friendly.
+
+Recommended behavior:
+
+- generate thumbnails on demand per queue slot
+- resize server-side to a small JPEG, for example around `96x72` or `128x96`
+- use the first image in a portrait pair as the thumbnail source in v1
+- apply EXIF-aware transpose before resizing so rotated images do not appear sideways
+- if generation fails, return a placeholder or an empty response that the UI can tolerate
+
+Implementation notes:
+
+- reuse the existing `heif_to_image()` helper for HEIC/HEIF sources
+- for standard image types, open via Pillow and then run `ImageOps.exif_transpose()`
+
+Do not:
+
+- precompute thumbnails for the whole playlist
+- decode many queue images during page render
+- build a large thumbnail grid
+
+### 7. Thumbnail caching
+
+Use a simple cache keyed by source identity, not by queue index alone.
+
+Recommended cache key inputs:
+
+- source file path
+- source file modification time
+- requested thumbnail size
+
+Acceptable implementations:
+
+- small in-memory cache
+- cache files in a lightweight temporary directory
+
+The cache does not need to be sophisticated. It only needs to avoid regenerating the same small preview repeatedly during normal use.
+
+Memory constraint:
+
+- the cache must be bounded
+- v1 should use a small cap, for example around 20 to 30 thumbnails, with simple LRU-style eviction
+
+### 8. Frontend rendering
+
+The queue UI should stay small and readable.
+
+Recommended queue card structure:
+
+- queue summary row
+  - current item label
+  - slot counter such as `14 / 286`
+- list of next 6 to 8 slots
+- each row contains
+  - small thumbnail box
+  - filename
+  - optional sublabel for second file in a pair
+  - `pair` badge when needed
+  - click target for jumping
+
+Avoid:
+
+- masonry layouts
+- infinite scrolling
+- client-side reordering
+- thumbnail animations
+
+The queue list should refresh:
+
+- on initial page load
+- after `next`, `back`, or jump actions
+- on a slow timer, for example 30 to 60 seconds
+
+Concrete JS integration rule:
+
+- add a dedicated `refreshQueue()` function in `pf_functions.js`
+- call it after successful `next`, `back`, and queue jump actions
+- keep preview-image refresh and queue refresh as two explicit steps in the existing action flow
+
+Do not rely on the jump endpoint to return a full updated queue payload unless there is a clear reason to do so.
+
+### 9. Data volume constraints
+
+The queue endpoint should return only a small window of the playlist.
+
+Recommended default:
+
+- current slot
+- next 8 slots
+
+Optional fields:
+
+- `remaining_slots`
+- `total_slots`
+
+Do not return the entire playlist by default, especially for large libraries.
+
+Filename lookup note:
+
+- `self.__file_list` stores file ids, not filenames
+- resolving display labels will require bounded lookups for the visible queue window
+- that cost is acceptable for a small window such as 6 to 8 slots, but should not be expanded to the full playlist by default
+
+If a larger queue view is desired later, add pagination in a future task.
+
+### 10. Pair-slot representation
+
+Portrait-pair slots should remain visible as one queue entry because that matches slideshow behavior.
+
+For queue display:
+
+- the row represents one playlist slot
+- show one thumbnail based on the first file in the pair
+- add a `pair` badge
+- optionally show both filenames in stacked text
+
+Do not split a pair into two separate clickable queue rows.
+
+---
+
+## Suggested UI Layout
+
+Lightweight target structure:
+
+```text
++----------------------------------------------------------------------------------+
+| PicFrame                                                           [ ON / OFF ] |
++----------------------------------------------------------------------------------+
+|                                                                                  |
+|                         main image preview with nav controls                      |
+|                                                                                  |
++----------------------------------------------------------------------------------+
+| Queue                                                            slot 14 / 286   |
+| [img] 15. park_walk_104.heic                                        [jump]       |
+| [img] 16. family_trip_008.jpg                                       [jump]       |
+| [img] 17. kids_011 + kids_012                                [pair] [jump]       |
+| [img] 18. kitchen_042.jpg                                          [jump]       |
+| [img] 19. garden_019.jpg                                           [jump]       |
+| [img] 20. album_201 + album_202                             [pair] [jump]       |
++----------------------------------------------------------------------------------+
+| display controls                    | text overlays                              |
+| filters                             | actions                                    |
++----------------------------------------------------------------------------------+
+```
+
+The queue card should sit close to the main preview because it is part of playback navigation, not secondary configuration.
+
+In the current HTML structure, insert the queue card between:
+
+- `<section class="frame-wrapper">`
+- and `<div id="controls">`
+
+Do not bury the queue inside `#controls`.
+
+### 11. Thread safety
+
+The HTTP server runs in its own thread, while slideshow playback and playlist reloads happen elsewhere.
+
+That means queue reads are concurrent with:
+
+- `get_next_file()`
+- playlist rebuilds
+- deletion and reload flows
+
+The implementation must take a stable snapshot before serializing queue state.
+
+Acceptable approaches:
+
+- protect queue reads and writes with a small lock around playlist state
+- or copy the relevant window of `self.__file_list` under a lock, then perform slower filename lookups after releasing it
+
+The goal is not perfect transactional semantics. The goal is to avoid reading half-updated playlist state or racing against a full playlist replacement.
+
+---
+
+## Test Coverage
+
+### Model / Controller tests
+
+Add focused tests for:
+
+1. queue snapshot shape for single-image slots
+2. queue snapshot shape for portrait-pair slots
+3. jump-to-slot sets the next position correctly
+4. invalid jump indices are clamped or rejected safely
+
+### HTTP tests
+
+Add targeted tests where practical for:
+
+1. queue endpoint returns compact JSON
+2. thumbnail endpoint returns image bytes or a safe fallback
+3. jump endpoint triggers queue movement without rebuilding the queue unexpectedly
+4. new queue endpoints remain under the existing auth guard
+
+### Frontend behavior checks
+
+At minimum, verify manually that:
+
+1. page renders before thumbnails finish loading
+2. queue list updates after navigation
+3. clicking a queue row jumps to that slot
+4. portrait pair rows remain single queue entries
+
+---
+
+## Manual Verification
+
+Verify using a mixed library that includes:
+
+- normal landscape images
+- portrait pairs
+- HEIC or other slower-to-decode formats when available
+- a reasonably large library so queue and caching behavior are noticeable
+
+Expected results:
+
+1. the HTTP page opens quickly even on slower hardware
+2. queue text appears before thumbnails if thumbnail generation is slow
+3. thumbnails populate progressively
+4. clicking a queued slot skips ahead correctly
+5. current slot and queue preview stay in sync after `next`, `back`, and jump
+6. repeated visits do not regenerate every thumbnail unnecessarily
+7. queued jumps fail cleanly when a playlist reload is already pending
+
+---
+
+## Acceptance Criteria
+
+This task is complete when all of the following are true:
+
+- the web panel shows a queue preview of upcoming playlist slots
+- queue entries are clickable and can jump playback to the selected slot
+- portrait-pair slots remain one queue row
+- queue thumbnails are shown for the visible queue window
+- initial page render does not block on thumbnail generation
+- thumbnail generation is done on demand and is cached
+- the queue endpoint returns only a small window of playlist state
+- the implementation remains lightweight enough for low-power Raspberry Pi devices
+
+---
+
+## Implementation Notes For The Assignee
+
+- Prefer a queue preview window of 6 to 8 visible items in v1.
+- Use separate requests for metadata and thumbnails; do not render thumbs inline into the initial HTML.
+- Keep queue rendering text-first so the UI remains useful even if thumbnails fail.
+- Treat click-to-jump as “set next slot and advance”, not queue reordering.
+- Be conservative with thumbnail size and generation cost.
+- Favor simple bounded caching over clever caching.
+- Keep the HTTP layer thin; business logic belongs in model/controller.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# Picframe Custom Fork
+
+Custom fork of [helgeerbe/picframe](https://github.com/helgeerbe/picframe) via [ravado/picframe](https://github.com/ravado/picframe).
+Raspberry Pi-based digital picture frame with pi3d rendering, MQTT/Home Assistant integration, and HTTP config UI.
+
+## Repository Layout
+
+```
+picframe/                          # Git repo root (branch: develop)
+  src/picframe/                    # Python package source (installed as `picframe`)
+    start.py                       # Entry point — CLI, init (`picframe -i`), main loop
+    model.py                       # Config loading, DB, file management. DEFAULT_CONFIG dict has all defaults
+    viewer_display.py              # pi3d rendering, text/clock/sensor overlays
+    controller.py                  # Orchestrates Model + Viewer + MQTT + HTTP + Peripherals
+    interface_mqtt.py              # MQTT client, Home Assistant auto-discovery, state publishing
+    interface_http.py              # HTTP config server
+    get_sensors_data.py            # [CUSTOM] DHT22 + BME280 sensor monitoring (background thread)
+    gpio_actions.py                # [CUSTOM] Clap detection + touch buttons via gpiod
+    dht_compat.py                  # [CUSTOM] Adapter: new adafruit_dht API -> old Adafruit_DHT API
+    geo_reverse.py                 # [CUSTOM] OpenStreetMap Nominatim reverse geocoding
+    gpio_fake_frame_controller.py  # [CUSTOM] Mock GPIO for dev/testing
+    config/configuration_example.yaml  # Config template (copied during `picframe -i`)
+    data/                          # Bundled resources (fonts, shaders, images) — copied during init
+    html/                          # Web UI files — copied during init
+  picframe_data/                   # Runtime data directory (deployed instance)
+    config/configuration.yaml      # Active config (gitignored, user creates from example)
+    data/                          # Fonts, shaders, DB, etc.
+    html/                          # Served by HTTP interface
+  pyproject.toml                   # Package config, dependencies, entry point: picframe.start:main
+  .gitignore                       # Ignores configuration.yaml, DB, logs, IDE, Python artifacts
+```
+
+## Architecture (MVC + Peripherals)
+
+```
+start.py  ->  Model (config, DB, files)
+          ->  ViewerDisplay (pi3d rendering)
+          ->  Controller (orchestrates all)
+                -> InterfaceMQTT (HA discovery, state pub/sub)
+                -> InterfaceHTTP (web config UI)
+                -> InterfacePeripherals (keyboard/touch/mouse input)
+          ->  GpioController [optional] (clap sensor, touch buttons)
+          ->  SensorData [optional] (DHT22 outside, BME280 inside)
+```
+
+## Config System
+
+- **Sections:** `viewer`, `model`, `mqtt`, `http`, `peripherals`, `gpio`
+- **Defaults:** `DEFAULT_CONFIG` dict in `model.py` — all keys must exist here
+- **Loading:** `model.py:163` merges YAML over defaults: `{**DEFAULT_CONFIG[section], **conf[section]}`
+- **Access:** `model.get_viewer_config()`, `get_model_config()`, `get_mqtt_config()`, etc.
+- **Init flow:** `picframe -i <dest>` copies `src/picframe/{data,config,html}/` -> `<dest>/picframe_data/`
+  then generates `configuration.yaml` from example with user-prompted path substitutions
+
+## Custom Additions (vs upstream)
+
+### Sensor Monitoring (`get_sensors_data.py`)
+- `SensorData` class reads DHT22 (outside, GPIO pin) and BME280 (inside, I2C address)
+- Background daemon thread polls at configurable rate (default 60s)
+- Observer pattern: subscribers notified on data change (hash-based dedup)
+- Config keys in `viewer` section: `show_sensors`, `sensors_justify`, `sensors_text_sz`, `sensors_opacity`, `sensors_update_rate_in_seconds`, `outside_sensor_pin`, `inside_sensor_address`
+- Hardware libs: `board`, `busio`, `adafruit_dht` (via `dht_compat.py`), `adafruit_bme280`
+
+### GPIO Control (`gpio_actions.py`)
+- `GpioController` uses `gpiod` library for Raspberry Pi GPIO
+- Clap detection (GPIO 4) with single/double clap discrimination (700ms delay)
+- Touch buttons: previous (GPIO 20), next (GPIO 21) — currently commented out
+- Config section: `gpio` with `use_gpio`, pin numbers, `clap_delay`
+
+### Sensor Display Overlay (`viewer_display.py`)
+- `__draw_sensors()` renders temperature/humidity/pressure with Font Awesome icons
+- Icon font: `Font Awesome 6 Free-Solid-900.otf` (glyphs: `\uf015` house, `\ue587` tree)
+- Config key: `font_icon_file` for icon font path
+
+### MQTT Sensor Publishing (`interface_mqtt.py`)
+- 6 HA sensors: `inside_temperature`, `inside_humidity`, `inside_pressure`, `outside_*`
+- Published in `sensor_state_payload` alongside standard picframe state
+
+### Geo Reverse Lookup (`geo_reverse.py`)
+- `GeoReverse` class using OpenStreetMap Nominatim API
+- Converts GPS coords to addresses with configurable zoom and key_list
+
+## Key Patterns
+
+- **Config injection:** All components accept config dict from `model.get_*_config()` methods
+- **Lazy hardware imports:** Hardware libs (`gpiod`, `board`, `busio`, `adafruit_*`) should be imported inside try/except, not at module level — non-Pi systems must not crash
+- **Graceful fallback:** All hardware features must degrade silently if libs/hardware unavailable
+- **Daemon threads:** `SensorData.fetch_sensor_data()` and `GpioController.__event_loop()` run as daemon threads with stop signals
+- **Observer pattern:** `SensorData` notifies subscribers via `subscribe_to_sensors_updates(callback)`
+
+## Known Issues / Compatibility Gaps
+
+See `.claude/plans/backward-compatibility-plan.md` for the full remediation plan.
+
+Key issues:
+- Several custom features lack proper defaults in `DEFAULT_CONFIG` causing `KeyError` without custom YAML
+- Hardware imports at module level cause `ImportError` on non-Pi systems
+- `gpio_actions` imported unconditionally in `start.py`
+- Icon font not bundled in `src/picframe/data/fonts/` (missing from `picframe -i` flow)
+- Hardware deps not in `pyproject.toml` (should be optional extras)
+
+## Planning & Task Management
+
+**All implementation plans and task documentation should be kept in `.claude/plans/` directory.**
+
+Current plans:
+- `backward-compatibility-plan.md` — Remediation for upstream compatibility gaps
+- `memories-feature.md` — Feature implementation plan
+- `task-001.md` — Specific task documentation
+
+When creating new plans or tasks, add them to this folder with descriptive names following the pattern:
+- Feature plans: `feature-name-plan.md`
+- Task tracking: `task-NNN.md` (numbered sequentially)
+- Architecture decisions: `adr-NNN-topic.md`
+
+## Development
+
+- **Remote:** `git@github.com:ravado/picframe.git`
+- **Branch:** `develop`
+- **Python:** >=3.7 (targets 3.11-3.13)
+- **Target platform:** Raspberry Pi (Linux/ARM), development on macOS
+- **Entry point:** `picframe` CLI or `python -m picframe.start`
+- **No test framework configured** — `test/` directory exists but minimal

--- a/picframe_data/html/index.html
+++ b/picframe_data/html/index.html
@@ -1,52 +1,62 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <meta name="viewport" content="width=device-width, inital-scale=1"/>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>PicFrame</title>
+    <link rel="stylesheet" href="style.css"/>
 </head>
-    <body onload="setStyle(); createSpans(); refreshData();">
-        <script type="text/javascript">
-            /* widths to use for spans. Other slots in the array could be used for other
-             things...
-            */
-            const TYPES = {"bool":[5,], "text":[15,], "date":[10,], "number":[5,], "action":[5,]};
+<body>
+    <script>
+    const ids = {
+        "back":              {type:"action", fn:"back={}",                                                val:false, group:"nav"},
+        "next":              {type:"action", fn:"next={}",                                                val:false, group:"nav"},
+        "paused":            {type:"bool",   fn:"setter",                                                 val:false, group:"nav"},
 
-            /* this is used to render the ids on this page.
-             fn is a method of controller
-             underscores will be replaced by spaces but it's also possible to use
-             an alternative "desc":"..." field
-            */
-            const ids = {
-                "back": {type:"action", fn:"back={}", val:false},
-                "next": {type:"action", fn:"next={}", val:false},
-                "paused": {type:"bool", fn:"setter", val:false},
-                "display_is_on": {type:"bool", fn:"setter", val:false},
-                "shuffle": {type:"bool", fn:"setter", val:false},
-                "text_name": {type:"bool", fn:"set_show_text={\"txt_key\":\"name\",\"val\":$val}", val:false},
-                "text_date": {type:"bool", fn:"set_show_text={\"txt_key\":\"date\",\"val\":$val}", val:false},
-                "text_folder": {type:"bool", fn:"set_show_text={\"txt_key\":\"folder\",\"val\":$val}", val:false},
-                "text_location": {type:"bool", fn:"set_show_text={\"txt_key\":\"location\",\"val\":$val}", val:false},
-                "clear_text": {type:"action", fn:"set_show_text={}", val:false},
-                "refresh_show_text": {type:"action", fn:"refresh_show_text={}", val:false},
+        "display_is_on":     {type:"bool",   fn:"setter",                                                 val:false, group:"display"},
+        "shuffle":           {type:"bool",   fn:"setter",                                                 val:false, group:"display"},
+        "brightness":        {type:"number", fn:"setter",                                                 val:0,     group:"display"},
+        "fade_time":         {type:"number", fn:"setter",                                                 val:0,     group:"display"},
+        "time_delay":        {type:"number", fn:"setter",                                                 val:0,     group:"display"},
 
-                "date_from": {type:"date", fn:"setter", val:0},
-                "date_to": {type:"date", fn:"setter", val:0},
-                "fade_time": {type:"number", fn:"setter", val:0},
-                "time_delay": {type:"number", fn:"setter", val:0},
-                "brightness": {type:"number", fn:"setter", val:0},
-                "subdirectory": {type:"text", fn:"setter", val:""},
-                "location_filter": {type:"text", fn:"setter", val:""},
-                "tags_filter": {type:"text", fn:"setter", val:""},
-                "delete": {type:"action", fn:"delete={}", val:false},
-                "purge_files": {type:"action", fn:"purge_files={}", val:false},
-                "stop": {type:"action", fn:"stop={}", val:false},
-                };
-        </script>
-        <script type="text/javascript" src="pf_functions.js"></script>
-        <h1>Simple Picture Frame page</h1>
-        <div id="spans">
+        "text_name":         {type:"bool",   fn:"set_show_text={\"txt_key\":\"name\",\"val\":$val}",     val:false, group:"text"},
+        "text_date":         {type:"bool",   fn:"set_show_text={\"txt_key\":\"date\",\"val\":$val}",     val:false, group:"text"},
+        "text_folder":       {type:"bool",   fn:"set_show_text={\"txt_key\":\"folder\",\"val\":$val}",   val:false, group:"text"},
+        "text_location":     {type:"bool",   fn:"set_show_text={\"txt_key\":\"location\",\"val\":$val}", val:false, group:"text"},
+        "clear_text":        {type:"action", fn:"set_show_text={}",                                       val:false, group:"text"},
+        "refresh_show_text": {type:"action", fn:"refresh_show_text={}",                                   val:false, group:"text"},
+
+        "date_from":         {type:"date",   fn:"setter",                                                 val:0,     group:"filter"},
+        "date_to":           {type:"date",   fn:"setter",                                                 val:0,     group:"filter"},
+        "subdirectory":      {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
+        "location_filter":   {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
+        "tags_filter":       {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
+
+        "delete":            {type:"action", fn:"delete={}",                                              val:false, group:"actions"},
+        "purge_files":       {type:"action", fn:"purge_files={}",                                         val:false, group:"actions"},
+        "stop":              {type:"action", fn:"stop={}",                                                val:false, group:"actions"},
+    };
+    </script>
+
+    <header>
+        <h1>PicFrame</h1>
+    </header>
+
+    <main>
+        <section class="preview-section">
+            <a href="/current_image">
+                <img id="preview-img" src="/current_image" alt="Current image" onerror="this.style.visibility='hidden'"/>
+            </a>
+            <a href="/current_image_original" class="original-link">original</a>
+        </section>
+
+        <div id="controls"></div>
+
+        <div class="update-row">
+            <button id="upload_button" onclick="uploadValues()">Apply Changes</button>
         </div>
-        <button id="upload_button" onclick="uploadValues()">UPDATE</button>
-        <a href="/current_image">See the current image</a> (use browser BACK to return to this page)
-    </body>
+    </main>
+
+    <script src="pf_functions.js"></script>
+</body>
 </html>

--- a/picframe_data/html/index.html
+++ b/picframe_data/html/index.html
@@ -31,24 +31,24 @@
                         <img id="preview-img" src="/current_image" alt="Current image" onerror="this.style.visibility='hidden'"/>
                     </a>
                 </div>
+
+                <!-- Nav overlay on image -->
+                {% for group in groups if group.key == "nav" %}
+                    {% for ctrl in group.controls if ctrl.id == "back" %}
+                        <button class="nav-overlay nav-overlay--left pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Back">&#9665;</button>
+                    {% endfor %}
+                    {% for ctrl in group.controls if ctrl.id == "next" %}
+                        <button class="nav-overlay nav-overlay--right pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Next">&#9655;</button>
+                    {% endfor %}
+                    {% for ctrl in group.controls if ctrl.id == "paused" %}
+                        {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                        <button class="nav-overlay nav-overlay--pause {{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">
+                            {{ "&#9646;&#9646; Paused" if ctrl.val else "&#9654; Playing" }}
+                        </button>
+                    {% endfor %}
+                {% endfor %}
             </div>
             <a href="/current_image_original" class="original-link">original</a>
-
-            <!-- Nav overlay on image -->
-            {% for group in groups if group.key == "nav" %}
-                {% for ctrl in group.controls if ctrl.id == "back" %}
-                    <button class="nav-overlay nav-overlay--left pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Back">&#9665;</button>
-                {% endfor %}
-                {% for ctrl in group.controls if ctrl.id == "next" %}
-                    <button class="nav-overlay nav-overlay--right pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Next">&#9655;</button>
-                {% endfor %}
-                {% for ctrl in group.controls if ctrl.id == "paused" %}
-                    {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
-                    <button class="nav-overlay nav-overlay--pause {{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">
-                        {{ "&#9646;&#9646; Paused" if ctrl.val else "&#9654; Playing" }}
-                    </button>
-                {% endfor %}
-            {% endfor %}
         </section>
 
         <div id="controls">

--- a/picframe_data/html/index.html
+++ b/picframe_data/html/index.html
@@ -7,36 +7,7 @@
     <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
-    <script>
-    const ids = {
-        "back":              {type:"action", fn:"back={}",                                                val:false, group:"nav"},
-        "next":              {type:"action", fn:"next={}",                                                val:false, group:"nav"},
-        "paused":            {type:"bool",   fn:"setter",                                                 val:false, group:"nav"},
-
-        "display_is_on":     {type:"bool",   fn:"setter",                                                 val:false, group:"display"},
-        "shuffle":           {type:"bool",   fn:"setter",                                                 val:false, group:"display"},
-        "brightness":        {type:"number", fn:"setter",                                                 val:0,     group:"display"},
-        "fade_time":         {type:"number", fn:"setter",                                                 val:0,     group:"display"},
-        "time_delay":        {type:"number", fn:"setter",                                                 val:0,     group:"display"},
-
-        "text_name":         {type:"bool",   fn:"set_show_text={\"txt_key\":\"name\",\"val\":$val}",     val:false, group:"text"},
-        "text_date":         {type:"bool",   fn:"set_show_text={\"txt_key\":\"date\",\"val\":$val}",     val:false, group:"text"},
-        "text_folder":       {type:"bool",   fn:"set_show_text={\"txt_key\":\"folder\",\"val\":$val}",   val:false, group:"text"},
-        "text_location":     {type:"bool",   fn:"set_show_text={\"txt_key\":\"location\",\"val\":$val}", val:false, group:"text"},
-        "clear_text":        {type:"action", fn:"set_show_text={}",                                       val:false, group:"text"},
-        "refresh_show_text": {type:"action", fn:"refresh_show_text={}",                                   val:false, group:"text"},
-
-        "date_from":         {type:"date",   fn:"setter",                                                 val:0,     group:"filter"},
-        "date_to":           {type:"date",   fn:"setter",                                                 val:0,     group:"filter"},
-        "subdirectory":      {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
-        "location_filter":   {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
-        "tags_filter":       {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
-
-        "delete":            {type:"action", fn:"delete={}",                                              val:false, group:"actions"},
-        "purge_files":       {type:"action", fn:"purge_files={}",                                         val:false, group:"actions"},
-        "stop":              {type:"action", fn:"stop={}",                                                val:false, group:"actions"},
-    };
-    </script>
+    <script>const ids = {{ ids_json }};</script>
 
     <header>
         <h1>PicFrame</h1>
@@ -50,7 +21,38 @@
             <a href="/current_image_original" class="original-link">original</a>
         </section>
 
-        <div id="controls"></div>
+        <div id="controls">
+            {% for group in groups %}
+            <div class="card{% if group.danger %} card--danger{% endif %}">
+                <div class="card-title">{{ group.label }}</div>
+                <div class="card-body">
+                    {% for ctrl in group.controls %}
+                    {% if ctrl.type in ("bool", "action") %}
+                        {% if ctrl.type == "bool" %}
+                            {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                        {% elif group.danger %}
+                            {% set btn_class = "pf-btn pf-btn--danger" %}
+                        {% else %}
+                            {% set btn_class = "pf-btn pf-btn--action" %}
+                        {% endif %}
+                        <button class="{{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
+                    {% else %}
+                        <div class="pf-field{% if ctrl.type == 'text' %} pf-field--wide{% endif %}">
+                            <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
+                            {% if ctrl.type == "number" %}
+                                <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:5ch">
+                            {% elif ctrl.type == "date" %}
+                                <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:10ch">
+                            {% else %}
+                                <input id="{{ ctrl.id }}" type="text" value="{{ ctrl.val }}">
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
 
         <div class="update-row">
             <button id="upload_button" onclick="uploadValues()">Apply Changes</button>

--- a/picframe_data/html/index.html
+++ b/picframe_data/html/index.html
@@ -10,44 +10,126 @@
     <script>const ids = {{ ids_json }};</script>
 
     <header>
-        <h1>PicFrame</h1>
+        <span class="header-title">PicFrame</span>
+        {% for group in groups if group.key == "display" %}
+            {% for ctrl in group.controls if ctrl.id == "display_is_on" %}
+                {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                <button class="header-power {{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">
+                    <span class="power-icon">&#9679;</span>
+                    <span class="power-label">{{ "ON" if ctrl.val else "OFF" }}</span>
+                </button>
+            {% endfor %}
+        {% endfor %}
     </header>
 
     <main>
-        <section class="preview-section">
-            <a href="/current_image">
-                <img id="preview-img" src="/current_image" alt="Current image" onerror="this.style.visibility='hidden'"/>
-            </a>
+        <!-- Photo with frame -->
+        <section class="frame-wrapper">
+            <div class="frame">
+                <div class="frame-mat">
+                    <a href="/current_image" class="frame-img-link">
+                        <img id="preview-img" src="/current_image" alt="Current image" onerror="this.style.visibility='hidden'"/>
+                    </a>
+                </div>
+            </div>
             <a href="/current_image_original" class="original-link">original</a>
+
+            <!-- Nav overlay on image -->
+            {% for group in groups if group.key == "nav" %}
+                {% for ctrl in group.controls if ctrl.id == "back" %}
+                    <button class="nav-overlay nav-overlay--left pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Back">&#9665;</button>
+                {% endfor %}
+                {% for ctrl in group.controls if ctrl.id == "next" %}
+                    <button class="nav-overlay nav-overlay--right pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Next">&#9655;</button>
+                {% endfor %}
+                {% for ctrl in group.controls if ctrl.id == "paused" %}
+                    {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                    <button class="nav-overlay nav-overlay--pause {{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">
+                        {{ "&#9646;&#9646; Paused" if ctrl.val else "&#9654; Playing" }}
+                    </button>
+                {% endfor %}
+            {% endfor %}
         </section>
 
         <div id="controls">
-            {% for group in groups %}
-            <div class="card{% if group.danger %} card--danger{% endif %}">
+            <!-- Display (without display_is_on, which is in header) -->
+            {% for group in groups if group.key == "display" %}
+            <div class="card">
+                <div class="card-title">{{ group.label }}</div>
+                <div class="card-body">
+                    {% for ctrl in group.controls if ctrl.id != "display_is_on" %}
+                        {% if ctrl.type == "bool" %}
+                            {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                            <button class="{{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
+                        {% elif ctrl.id == "brightness" %}
+                            <div class="pf-field pf-field--slider">
+                                <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
+                                <div class="slider-row">
+                                    <input type="range" id="{{ ctrl.id }}_slider" min="0" max="100" value="{{ ctrl.val }}" oninput="document.getElementById('{{ ctrl.id }}').value=this.value">
+                                    <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:5ch" class="slider-value" oninput="document.getElementById('{{ ctrl.id }}_slider').value=this.value">
+                                </div>
+                            </div>
+                        {% else %}
+                            <div class="pf-field">
+                                <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
+                                <div class="input-with-unit">
+                                    <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:6ch">
+                                    <span class="unit">s</span>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+
+            <!-- Text Overlays -->
+            {% for group in groups if group.key == "text" %}
+            <div class="card">
                 <div class="card-title">{{ group.label }}</div>
                 <div class="card-body">
                     {% for ctrl in group.controls %}
-                    {% if ctrl.type in ("bool", "action") %}
                         {% if ctrl.type == "bool" %}
                             {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
-                        {% elif group.danger %}
-                            {% set btn_class = "pf-btn pf-btn--danger" %}
+                            <button class="{{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') | replace('text ', '') }}</button>
                         {% else %}
-                            {% set btn_class = "pf-btn pf-btn--action" %}
+                            <button class="pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
                         {% endif %}
-                        <button class="{{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
-                    {% else %}
-                        <div class="pf-field{% if ctrl.type == 'text' %} pf-field--wide{% endif %}">
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+
+            <!-- Filters -->
+            {% for group in groups if group.key == "filter" %}
+            <div class="card">
+                <div class="card-title">{{ group.label }}</div>
+                <div class="card-body card-body--stack">
+                    <div class="filter-dates">
+                        {% for ctrl in group.controls if ctrl.type == "date" %}
+                        <div class="pf-field">
                             <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
-                            {% if ctrl.type == "number" %}
-                                <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:5ch">
-                            {% elif ctrl.type == "date" %}
-                                <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:10ch">
-                            {% else %}
-                                <input id="{{ ctrl.id }}" type="text" value="{{ ctrl.val }}">
-                            {% endif %}
+                            <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:12ch">
                         </div>
-                    {% endif %}
+                        {% endfor %}
+                    </div>
+                    {% for ctrl in group.controls if ctrl.type == "text" %}
+                    <div class="pf-field pf-field--wide">
+                        <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
+                        <input id="{{ ctrl.id }}" type="text" value="{{ ctrl.val }}">
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+
+            <!-- Danger zone -->
+            {% for group in groups if group.key == "actions" %}
+            <div class="card card--danger">
+                <div class="card-title card-title--danger">&#9888; {{ group.label }}</div>
+                <div class="card-body">
+                    {% for ctrl in group.controls %}
+                        <button class="pf-btn pf-btn--danger" data-resting="pf-btn pf-btn--danger" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
                     {% endfor %}
                 </div>
             </div>

--- a/picframe_data/html/index.html
+++ b/picframe_data/html/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
-    <script>const ids = {{ ids_json }};</script>
+    <script>const ids = {{ ids | tojson }};</script>
 
     <header>
         <span class="header-title">PicFrame</span>

--- a/picframe_data/html/pf_functions.js
+++ b/picframe_data/html/pf_functions.js
@@ -1,3 +1,13 @@
+const TYPES = {"bool": 5, "text": 15, "date": 10, "number": 5, "action": 5};
+
+const GROUPS = {
+    "nav":     {label: "Navigation",    danger: false},
+    "display": {label: "Display",       danger: false},
+    "text":    {label: "Text Overlays", danger: false},
+    "filter":  {label: "Filters",       danger: false},
+    "actions": {label: "Actions",       danger: true},
+};
+
 
 async function getData() {
     const response = await fetch("/?all");
@@ -6,27 +16,48 @@ async function getData() {
 
 
 function createSpans() {
-    let span_div_html = "";
-    /* ids is defined in index.html */
-    Object.entries(ids).forEach(([element_id, element]) => {
-        let description = element_id.replace("_", " ");
-        if (element.desc !== undefined) {
-            description = element.desc;
-        }
-        if (element.type === "bool" || element.type === "action") {
-            span_div_html += `<span class="pf_span off" id=${element_id} onclick="toggle('${element_id}')">${description}</span>`
-        } else {
-            width = TYPES[element.type][0];
-            span_div_html += `<span class="pf_span">${description} <input id="${element_id}"  style="width: ${width}ch;"></span>`;
-        }
+    const grouped = {};
+    Object.entries(ids).forEach(([id, el]) => {
+        const g = el.group || "other";
+        if (!grouped[g]) grouped[g] = [];
+        grouped[g].push([id, el]);
     });
-    span_div = document.getElementById("spans");
-    span_div.innerHTML = span_div_html;
 
-    // make enter press upload button
-    span_div.addEventListener("keyup", event => {
-        if (event.keyCode === 13) { // enter key
-            event.preventDefault();
+    let html = "";
+    Object.entries(GROUPS).forEach(([groupKey, groupInfo]) => {
+        const items = grouped[groupKey];
+        if (!items || items.length === 0) return;
+
+        html += `<div class="card${groupInfo.danger ? " card--danger" : ""}">`;
+        html += `<div class="card-title">${groupInfo.label}</div>`;
+        html += `<div class="card-body">`;
+
+        items.forEach(([id, el]) => {
+            const label = (el.desc !== undefined) ? el.desc : id.replace(/_/g, " ");
+
+            if (el.type === "bool" || el.type === "action") {
+                const btnClass = el.type === "action"
+                    ? (groupInfo.danger ? "pf-btn pf-btn--danger" : "pf-btn pf-btn--action")
+                    : "pf-btn pf-btn--off";
+                html += `<button class="${btnClass}" data-resting="${btnClass}" id="${id}" onclick="toggle('${id}')">${label}</button>`;
+            } else {
+                const widthAttr = el.type === "text" ? "" : ` style="width:${TYPES[el.type]}ch"`;
+                html += `<div class="pf-field${el.type === "text" ? " pf-field--wide" : ""}">`;
+                html += `<label for="${id}">${label}</label>`;
+                html += `<input id="${id}"${widthAttr}>`;
+                html += `</div>`;
+            }
+        });
+
+        html += `</div></div>`;
+    });
+
+    const container = document.getElementById("controls");
+    container.innerHTML = html;
+
+    container.addEventListener("keyup", e => {
+        if (e.key === "Enter") {
+            e.preventDefault();
             uploadValues();
         }
     });
@@ -34,137 +65,97 @@ function createSpans() {
 
 
 function isNumeric(num) {
-    return (typeof(num) === 'number' || typeof(num) === "string" && num.trim() !== '') && !isNaN(num);
+    return (typeof num === "number" || (typeof num === "string" && num.trim() !== "")) && !isNaN(num);
 }
 
 
 function refreshPage() {
-    Object.entries(ids).forEach(([element_id, element]) => { //ids declared previous to this script in each page
-        let docElement = document.getElementById(element_id);
-        let value = element.val;
+    Object.entries(ids).forEach(([id, el]) => {
+        const elem = document.getElementById(id);
+        if (!elem) return;
+        let value = el.val;
+
         if (isNumeric(value)) {
             value = parseFloat(value);
-            if (element.type === "number") { // integer or float
-                if (Math.floor(value) !== value) { //float
-                    value = value.toFixed(2);
-                }
-            } else if (element.type === "date") {
-                date = new Date(value * 1000); // js uses ms
-                value = `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
+            if (el.type === "number") {
+                if (Math.floor(value) !== value) value = value.toFixed(2);
+            } else if (el.type === "date") {
+                const d = new Date(value * 1000);
+                value = `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`;
             }
-        } else if (element.type === "bool") {
-            if (value == true || value === "true" || value === "True" || value === "ON") {
-                value = "true";
-            } else {
-                value = "false";
-            }
+        } else if (el.type === "bool") {
+            value = (value === true || value === "true" || value === "True" || value === "ON");
         }
-        docElement.value = value; //TODO have some fields not changed by ids.val?
-        element.val = value; // reset to refreshed version TODO check this is necessary?
-        if (element.type === "bool") {
-            docElement.className = (element.val ? "pf_span on" : "pf_span off");
+
+        elem.value = value;
+        el.val = value;
+
+        if (el.type === "bool") {
+            elem.className = el.val ? "pf-btn pf-btn--on" : "pf-btn pf-btn--off";
         }
     });
 }
 
 
 function refreshData() {
-    getData().then(ret_val => {
-        let data_changed = false;
-        Object.entries(ret_val).forEach(([key, val]) => {
+    getData().then(data => {
+        let changed = false;
+        Object.entries(data).forEach(([key, val]) => {
             if (key in ids && ids[key].val != val) {
-                data_changed = true;
+                changed = true;
                 ids[key].val = val;
             }
         });
-        if (data_changed) {
-            refreshPage();
-        }
-    });
+        if (changed) refreshPage();
+    }).catch(() => {});
 }
 
 
 function repeatRefresh() {
     refreshData();
-    setTimeout(repeatRefresh, 120000); //refresh every 120s in never-ending loop - faster occasionally changes values while being edited!
+    setTimeout(repeatRefresh, 120000);
 }
 
 
 function uploadValues() {
-    let data_changed = false;
-    Object.entries(ids).forEach(([element_id, element]) => { //ids declared previous to this script in each page
-        if (element.fn === "setter" && element.type !== "bool") { // done by toggle function.
-            let docElement = document.getElementById(element_id);
-            if (docElement.value != element.val) {
-                console.log("updating:" + element_id + "->" + docElement.value + ":was:" + element.val + ":");
-                element.val = docElement.value;
-                fetch(`/?${element_id}=${docElement.value}`).then(() => data_changed = true); //TODO do we need to refresh?
+    const fetches = [];
+    Object.entries(ids).forEach(([id, el]) => {
+        if (el.fn === "setter" && el.type !== "bool") {
+            const elem = document.getElementById(id);
+            if (!elem) return;
+            if (elem.value != el.val) {
+                el.val = elem.value;
+                fetches.push(fetch(`/?${id}=${elem.value}`));
             }
         }
     });
-    if (data_changed) { //TODO - is this necessary in ids.val changed here?
-        refreshData();
+    if (fetches.length > 0) {
+        Promise.all(fetches).then(() => refreshData());
     }
 }
 
 
 function toggle(id) {
-    let element = ids[id];
-    if (element.type === "bool") { //toggle val and class
-        element.val = !(element.val);
+    const el = ids[id];
+    if (el.type === "bool") {
+        el.val = !el.val;
     }
-    let cmd = `/?${id}=${element.val}`
-    if (element.fn !== "setter") { // i.e. use fn
-        cmd = `/?${element.fn}`;
-        cmd = cmd.replace('$val', element.val);
+
+    let cmd = `/?${id}=${el.val}`;
+    if (el.fn !== "setter") {
+        cmd = `/?${el.fn}`.replace("$val", el.val);
     }
-    let docElement = document.getElementById(id);
-    let css = (element.val ? "pf_span on" : "pf_span off"); // return to this
-    docElement.className = "pf_span flash";
-    console.log(cmd);
-    fetch(cmd).then(() => afterFlash(docElement, css));
+
+    const elem = document.getElementById(id);
+    const restingClass = el.type === "bool"
+        ? (el.val ? "pf-btn pf-btn--on" : "pf-btn pf-btn--off")
+        : (elem.dataset.resting || "pf-btn pf-btn--action");
+
+    elem.className = "pf-btn pf-btn--flash";
+    fetch(cmd).then(() => { elem.className = restingClass; });
 }
 
 
-function afterFlash(element, css) {
-    element.className = css; //TODO slight time delay?
-}
-
-
-// the super slimmed down python server doesn't load style sheets from file so this is
-// done using javascript!
-function setStyle() {
-    var x = document.createElement("STYLE");
-    var t = document.createTextNode("body {\
-        background-color: black;\
-        color:rgb(94, 89, 79);\
-        font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;\
-    }\
-    button {\
-        margin: 5px;\
-        padding: 10px;\
-        border: none;\
-        border-radius: 8px;\
-        font-weight: bold;\
-    }\
-    .off {\
-        background-color: maroon;\
-        color:powderblue;\
-    }\
-    .on {\
-        background-color: olivedrab;\
-        color:rebeccapurple;\
-    }\
-    .flash {\
-        background-color: orange;\
-        color:powderblue;\
-    }\
-    .pf_span {\
-        margin: 2px;\
-        padding: 4px;\
-        border-style: solid;\
-        display: inline-block;\
-    }");
-    x.appendChild(t);
-    document.head.appendChild(x);
-}
+// Initialise
+createSpans();
+repeatRefresh();

--- a/picframe_data/html/pf_functions.js
+++ b/picframe_data/html/pf_functions.js
@@ -129,6 +129,16 @@ function toggle(id) {
         } else {
             elem.className = restingClass;
         }
+
+        // Reload preview image after navigation actions
+        if (id === "back" || id === "next") {
+            const img = document.getElementById("preview-img");
+            if (img) {
+                setTimeout(() => {
+                    img.src = "/current_image?t=" + Date.now();
+                }, 500);
+            }
+        }
     });
 }
 

--- a/picframe_data/html/pf_functions.js
+++ b/picframe_data/html/pf_functions.js
@@ -31,7 +31,26 @@ function refreshPage() {
         el.val = value;
 
         if (el.type === "bool") {
-            elem.className = el.val ? "pf-btn pf-btn--on" : "pf-btn pf-btn--off";
+            elem.className = elem.className.replace(/pf-btn--on|pf-btn--off/g, "")
+                + (el.val ? " pf-btn--on" : " pf-btn--off");
+            elem.className = elem.className.replace(/\s+/g, " ").trim();
+
+            // Update power label if it's display_is_on
+            if (id === "display_is_on") {
+                const label = elem.querySelector(".power-label");
+                if (label) label.textContent = el.val ? "ON" : "OFF";
+            }
+
+            // Update pause button text
+            if (id === "paused") {
+                elem.innerHTML = el.val ? "&#9646;&#9646; Paused" : "&#9654; Playing";
+            }
+        }
+
+        // Sync brightness slider
+        const slider = document.getElementById(id + "_slider");
+        if (slider) {
+            slider.value = value;
         }
     });
 }
@@ -87,12 +106,30 @@ function toggle(id) {
     }
 
     const elem = document.getElementById(id);
-    const restingClass = el.type === "bool"
-        ? (el.val ? "pf-btn pf-btn--on" : "pf-btn pf-btn--off")
-        : (elem.dataset.resting || "pf-btn pf-btn--action");
+    const restingClass = elem.dataset.resting || elem.className;
 
-    elem.className = "pf-btn pf-btn--flash";
-    fetch(cmd).then(() => { elem.className = restingClass; });
+    // Flash
+    const origClasses = elem.className;
+    elem.className = origClasses.replace(/pf-btn--\w+/g, "") + " pf-btn--flash";
+    elem.className = elem.className.replace(/\s+/g, " ").trim();
+
+    fetch(cmd).then(() => {
+        if (el.type === "bool") {
+            const onOff = el.val ? "pf-btn--on" : "pf-btn--off";
+            elem.className = origClasses.replace(/pf-btn--on|pf-btn--off/g, onOff);
+            elem.className = elem.className.replace(/\s+/g, " ").trim();
+
+            if (id === "display_is_on") {
+                const label = elem.querySelector(".power-label");
+                if (label) label.textContent = el.val ? "ON" : "OFF";
+            }
+            if (id === "paused") {
+                elem.innerHTML = el.val ? "&#9646;&#9646; Paused" : "&#9654; Playing";
+            }
+        } else {
+            elem.className = restingClass;
+        }
+    });
 }
 
 

--- a/picframe_data/html/pf_functions.js
+++ b/picframe_data/html/pf_functions.js
@@ -1,66 +1,6 @@
-const TYPES = {"bool": 5, "text": 15, "date": 10, "number": 5, "action": 5};
-
-const GROUPS = {
-    "nav":     {label: "Navigation",    danger: false},
-    "display": {label: "Display",       danger: false},
-    "text":    {label: "Text Overlays", danger: false},
-    "filter":  {label: "Filters",       danger: false},
-    "actions": {label: "Actions",       danger: true},
-};
-
-
 async function getData() {
     const response = await fetch("/?all");
     return response.json();
-}
-
-
-function createSpans() {
-    const grouped = {};
-    Object.entries(ids).forEach(([id, el]) => {
-        const g = el.group || "other";
-        if (!grouped[g]) grouped[g] = [];
-        grouped[g].push([id, el]);
-    });
-
-    let html = "";
-    Object.entries(GROUPS).forEach(([groupKey, groupInfo]) => {
-        const items = grouped[groupKey];
-        if (!items || items.length === 0) return;
-
-        html += `<div class="card${groupInfo.danger ? " card--danger" : ""}">`;
-        html += `<div class="card-title">${groupInfo.label}</div>`;
-        html += `<div class="card-body">`;
-
-        items.forEach(([id, el]) => {
-            const label = (el.desc !== undefined) ? el.desc : id.replace(/_/g, " ");
-
-            if (el.type === "bool" || el.type === "action") {
-                const btnClass = el.type === "action"
-                    ? (groupInfo.danger ? "pf-btn pf-btn--danger" : "pf-btn pf-btn--action")
-                    : "pf-btn pf-btn--off";
-                html += `<button class="${btnClass}" data-resting="${btnClass}" id="${id}" onclick="toggle('${id}')">${label}</button>`;
-            } else {
-                const widthAttr = el.type === "text" ? "" : ` style="width:${TYPES[el.type]}ch"`;
-                html += `<div class="pf-field${el.type === "text" ? " pf-field--wide" : ""}">`;
-                html += `<label for="${id}">${label}</label>`;
-                html += `<input id="${id}"${widthAttr}>`;
-                html += `</div>`;
-            }
-        });
-
-        html += `</div></div>`;
-    });
-
-    const container = document.getElementById("controls");
-    container.innerHTML = html;
-
-    container.addEventListener("keyup", e => {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            uploadValues();
-        }
-    });
 }
 
 
@@ -156,6 +96,12 @@ function toggle(id) {
 }
 
 
-// Initialise
-createSpans();
+// Format initial values (dates, floats) and start polling
+refreshPage();
 repeatRefresh();
+document.getElementById("controls").addEventListener("keyup", e => {
+    if (e.key === "Enter") {
+        e.preventDefault();
+        uploadValues();
+    }
+});

--- a/picframe_data/html/style.css
+++ b/picframe_data/html/style.css
@@ -1,0 +1,256 @@
+:root {
+    --bg: #0f0f0f;
+    --bg-card: #1c1c1e;
+    --text: #e5e5ea;
+    --text-muted: #636366;
+    --accent: #0a84ff;
+    --btn-off-bg: #3a1212;
+    --btn-off-text: #ff9a9a;
+    --btn-on-bg: #1a3a1a;
+    --btn-on-text: #6ecc6e;
+    --btn-flash-bg: #b86000;
+    --btn-flash-text: #fff;
+    --btn-action-bg: #2c2c2e;
+    --btn-action-text: #c8c4bc;
+    --border: #2c2c2e;
+    --radius: 12px;
+    --gap: 12px;
+    --input-bg: #111;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.4;
+    min-height: 100vh;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+header {
+    padding: 14px 16px 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--text);
+}
+
+main {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+}
+
+/* ── Preview ── */
+
+.preview-section {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: #000;
+    aspect-ratio: 4 / 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.preview-section a:first-child {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.preview-section img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+}
+
+.original-link {
+    position: absolute;
+    bottom: 8px;
+    right: 10px;
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.55);
+    background: rgba(0, 0, 0, 0.55);
+    padding: 3px 9px;
+    border-radius: 20px;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+.original-link:hover {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+/* ── Cards ── */
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 13px 14px;
+}
+
+.card--danger {
+    border-color: #3a1212;
+}
+
+.card-title {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+}
+
+.card-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: flex-end;
+}
+
+/* ── Buttons ── */
+
+.pf-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 14px;
+    min-height: 40px;
+    border: none;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.1s;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    white-space: nowrap;
+    text-transform: capitalize;
+}
+
+.pf-btn:active {
+    opacity: 0.75;
+}
+
+.pf-btn--off,
+.pf-btn--danger {
+    background: var(--btn-off-bg);
+    color: var(--btn-off-text);
+}
+
+.pf-btn--on {
+    background: var(--btn-on-bg);
+    color: var(--btn-on-text);
+}
+
+.pf-btn--flash {
+    background: var(--btn-flash-bg);
+    color: var(--btn-flash-text);
+}
+
+.pf-btn--action {
+    background: var(--btn-action-bg);
+    color: var(--btn-action-text);
+    border: 1px solid var(--border);
+}
+
+/* ── Input fields ── */
+
+.pf-field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.pf-field--wide {
+    flex: 1;
+    min-width: 160px;
+}
+
+.pf-field label {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: capitalize;
+}
+
+.pf-field input {
+    background: var(--input-bg);
+    border: 1px solid #333;
+    border-radius: 7px;
+    color: var(--text);
+    font-size: 13px;
+    padding: 8px 10px;
+    min-height: 36px;
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+.pf-field--wide input {
+    width: 100%;
+}
+
+.pf-field input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+/* ── Update button ── */
+
+.update-row {
+    display: flex;
+    justify-content: flex-end;
+    padding-bottom: 8px;
+}
+
+#upload_button {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 10px;
+    padding: 11px 28px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    min-height: 44px;
+    -webkit-tap-highlight-color: transparent;
+}
+
+#upload_button:active {
+    opacity: 0.8;
+}
+
+/* ── Responsive ── */
+
+@media (max-width: 380px) {
+    main {
+        padding: 10px 12px;
+        gap: 10px;
+    }
+    .card {
+        padding: 11px 12px;
+    }
+}

--- a/picframe_data/html/style.css
+++ b/picframe_data/html/style.css
@@ -100,6 +100,7 @@ main {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: var(--gap);
+    align-items: start;
 }
 
 /* ── Photo Frame (Mat + Border style) ── */
@@ -112,6 +113,7 @@ main {
 }
 
 .frame {
+    position: relative;
     background: linear-gradient(145deg, #3d3225, #1e1810, #2a2018);
     padding: 4px;
     border-radius: 3px;
@@ -373,19 +375,19 @@ main {
 
 .slider-row input[type="range"] {
     flex: 1;
-    height: 4px;
+    height: 6px;
     -webkit-appearance: none;
     appearance: none;
-    background: #333;
-    border-radius: 2px;
+    background: #444;
+    border-radius: 3px;
     outline: none;
 }
 
 .slider-row input[type="range"]::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 18px;
-    height: 18px;
+    width: 22px;
+    height: 22px;
     border-radius: 50%;
     background: var(--accent);
     cursor: pointer;
@@ -393,8 +395,8 @@ main {
 }
 
 .slider-row input[type="range"]::-moz-range-thumb {
-    width: 18px;
-    height: 18px;
+    width: 22px;
+    height: 22px;
     border-radius: 50%;
     background: var(--accent);
     cursor: pointer;

--- a/picframe_data/html/style.css
+++ b/picframe_data/html/style.css
@@ -14,7 +14,7 @@
     --btn-action-text: #c8c4bc;
     --border: #2c2c2e;
     --radius: 12px;
-    --gap: 12px;
+    --gap: 20px;
     --input-bg: #111;
 }
 
@@ -39,7 +39,7 @@ a {
 }
 
 header {
-    padding: 14px 16px 12px;
+    padding: 14px 24px 12px;
     border-bottom: 1px solid var(--border);
 }
 
@@ -51,11 +51,17 @@ header h1 {
 }
 
 main {
-    max-width: 600px;
+    max-width: 1200px;
     margin: 0 auto;
-    padding: 14px 16px;
+    padding: 20px 24px;
     display: flex;
     flex-direction: column;
+    gap: var(--gap);
+}
+
+#controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
     gap: var(--gap);
 }
 
@@ -67,6 +73,7 @@ main {
     overflow: hidden;
     background: #000;
     aspect-ratio: 4 / 3;
+    max-height: 520px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -245,10 +252,13 @@ main {
 
 /* ── Responsive ── */
 
-@media (max-width: 380px) {
+@media (max-width: 500px) {
     main {
-        padding: 10px 12px;
-        gap: 10px;
+        padding: 12px;
+        gap: 12px;
+    }
+    #controls {
+        grid-template-columns: 1fr;
     }
     .card {
         padding: 11px 12px;

--- a/picframe_data/html/style.css
+++ b/picframe_data/html/style.css
@@ -16,6 +16,9 @@
     --radius: 12px;
     --gap: 20px;
     --input-bg: #111;
+    --frame-outer: #2a2018;
+    --frame-mat: #e8e0d4;
+    --danger-border: #5a2020;
 }
 
 * {
@@ -38,22 +41,56 @@ a {
     text-decoration: none;
 }
 
+/* ── Header ── */
+
 header {
-    padding: 14px 24px 12px;
+    padding: 12px 24px;
     border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
-header h1 {
+.header-title {
     font-size: 17px;
     font-weight: 600;
     letter-spacing: 0.02em;
     color: var(--text);
 }
 
+.header-power {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: none;
+    border-radius: 20px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.1s;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.header-power:active {
+    opacity: 0.75;
+}
+
+.power-icon {
+    font-size: 10px;
+}
+
+.power-label {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+/* ── Main layout ── */
+
 main {
-    max-width: 1200px;
+    max-width: 1100px;
     margin: 0 auto;
-    padding: 20px 24px;
+    padding: 24px 24px 100px;
     display: flex;
     flex-direction: column;
     gap: var(--gap);
@@ -61,52 +98,134 @@ main {
 
 #controls {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
     gap: var(--gap);
 }
 
-/* ── Preview ── */
+/* ── Photo Frame (Mat + Border style) ── */
 
-.preview-section {
+.frame-wrapper {
     position: relative;
-    border-radius: var(--radius);
-    overflow: hidden;
-    background: #000;
-    aspect-ratio: 4 / 3;
-    max-height: 520px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.frame {
+    background: linear-gradient(145deg, #3d3225, #1e1810, #2a2018);
+    padding: 4px;
+    border-radius: 3px;
+    box-shadow:
+        0 4px 20px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    max-width: 100%;
+}
+
+.frame-mat {
+    background: var(--frame-mat);
+    padding: 14px;
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-.preview-section a:first-child {
+.frame-img-link {
     display: block;
-    width: 100%;
-    height: 100%;
+    line-height: 0;
 }
 
-.preview-section img {
-    width: 100%;
-    height: 100%;
+.frame-img-link img {
+    max-width: 100%;
+    max-height: 480px;
     object-fit: contain;
     display: block;
 }
 
 .original-link {
-    position: absolute;
-    bottom: 8px;
-    right: 10px;
+    display: inline-block;
+    margin-top: 8px;
     font-size: 11px;
-    color: rgba(255, 255, 255, 0.55);
-    background: rgba(0, 0, 0, 0.55);
-    padding: 3px 9px;
+    color: var(--text-muted);
+    padding: 3px 10px;
     border-radius: 20px;
-    backdrop-filter: blur(6px);
-    -webkit-backdrop-filter: blur(6px);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    transition: color 0.15s;
 }
 
 .original-link:hover {
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--text);
+}
+
+/* ── Navigation overlays ── */
+
+.nav-overlay {
+    position: absolute;
+    border: none;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: opacity 0.15s, background 0.15s;
+    z-index: 2;
+}
+
+.nav-overlay--left,
+.nav-overlay--right {
+    top: 50%;
+    transform: translateY(-50%);
+    width: 44px;
+    height: 64px;
+    border-radius: 8px;
+    font-size: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(30, 30, 30, 0.7);
+    color: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+}
+
+.nav-overlay--left {
+    left: 8px;
+}
+
+.nav-overlay--right {
+    right: 8px;
+}
+
+.nav-overlay--left:hover,
+.nav-overlay--right:hover {
+    background: rgba(50, 50, 50, 0.85);
+    color: #fff;
+}
+
+.nav-overlay--pause {
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 500;
+    background: rgba(20, 20, 20, 0.75);
+    color: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    white-space: nowrap;
+}
+
+.nav-overlay--pause.pf-btn--on {
+    background: rgba(60, 30, 10, 0.8);
+    color: #ffb060;
+}
+
+.nav-overlay--pause.pf-btn--off {
+    background: rgba(20, 50, 20, 0.75);
+    color: #6ecc6e;
+}
+
+.nav-overlay--pause:hover {
+    opacity: 0.9;
 }
 
 /* ── Cards ── */
@@ -115,11 +234,12 @@ main {
     background: var(--bg-card);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 13px 14px;
+    padding: 14px 16px;
 }
 
 .card--danger {
-    border-color: #3a1212;
+    border-color: var(--danger-border);
+    background: linear-gradient(180deg, #1c1c1e 0%, #1a1214 100%);
 }
 
 .card-title {
@@ -128,7 +248,11 @@ main {
     letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--text-muted);
-    margin-bottom: 10px;
+    margin-bottom: 12px;
+}
+
+.card-title--danger {
+    color: #cc5555;
 }
 
 .card-body {
@@ -136,6 +260,16 @@ main {
     flex-wrap: wrap;
     gap: 8px;
     align-items: flex-end;
+}
+
+.card-body--stack {
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.filter-dates {
+    display: flex;
+    gap: 12px;
 }
 
 /* ── Buttons ── */
@@ -193,8 +327,12 @@ main {
 }
 
 .pf-field--wide {
+    width: 100%;
+}
+
+.pf-field--slider {
     flex: 1;
-    min-width: 160px;
+    min-width: 180px;
 }
 
 .pf-field label {
@@ -225,6 +363,62 @@ main {
     border-color: var(--accent);
 }
 
+/* ── Slider ── */
+
+.slider-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.slider-row input[type="range"] {
+    flex: 1;
+    height: 4px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #333;
+    border-radius: 2px;
+    outline: none;
+}
+
+.slider-row input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+    border: 2px solid var(--bg);
+}
+
+.slider-row input[type="range"]::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+    border: 2px solid var(--bg);
+}
+
+.slider-value {
+    text-align: center;
+    min-width: 5ch;
+}
+
+/* ── Input with unit suffix ── */
+
+.input-with-unit {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.input-with-unit .unit {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
 /* ── Update button ── */
 
 .update-row {
@@ -244,6 +438,7 @@ main {
     cursor: pointer;
     min-height: 44px;
     -webkit-tap-highlight-color: transparent;
+    transition: opacity 0.1s;
 }
 
 #upload_button:active {
@@ -252,15 +447,69 @@ main {
 
 /* ── Responsive ── */
 
-@media (max-width: 500px) {
+@media (max-width: 768px) {
     main {
-        padding: 12px;
-        gap: 12px;
+        padding: 16px 12px 90px;
+        gap: 14px;
     }
+
     #controls {
         grid-template-columns: 1fr;
     }
+
     .card {
-        padding: 11px 12px;
+        padding: 12px;
+    }
+
+    .frame-mat {
+        padding: 10px;
+    }
+
+    .frame-img-link img {
+        max-height: 360px;
+    }
+
+    .nav-overlay--left,
+    .nav-overlay--right {
+        width: 38px;
+        height: 52px;
+        font-size: 18px;
+    }
+
+    .filter-dates {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .filter-dates .pf-field input {
+        width: 100%;
+    }
+
+    /* Sticky apply button */
+    .update-row {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: var(--bg-card);
+        border-top: 1px solid var(--border);
+        padding: 12px 16px;
+        justify-content: stretch;
+        z-index: 10;
+    }
+
+    #upload_button {
+        width: 100%;
+    }
+}
+
+@media (max-width: 380px) {
+    .frame-mat {
+        padding: 6px;
+    }
+
+    .pf-btn {
+        padding: 7px 10px;
+        font-size: 12px;
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "ninepatch>=0.2.0",
     "pi_heif>=0.8.0",
     "python-vlc",
+    "jinja2",
     "rubicon-objc; sys_platform == 'darwin'"
 ]
 

--- a/scripts/check_date_range_files.py
+++ b/scripts/check_date_range_files.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Inspect Picframe cache entries for a date range and verify files on disk.
+
+This script mirrors Picframe's date filtering behavior:
+- It filters on `meta.exif_datetime`
+- If EXIF DateTimeOriginal was missing when the cache was built, Picframe stored
+  the file modification time instead
+
+The script reports:
+- how many cached rows match the range
+- which matched files currently exist or are missing on disk
+- duplicate timestamps that may indicate only one photo truly falls in range
+
+Example:
+    python3 check_date_range_files.py \
+      --db ~/picframe_data/data/pictureframe.db3 \
+      --date-from 2016/04/08 \
+      --date-to 2016/04/09
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import sqlite3
+import sys
+from collections import Counter
+
+
+def parse_date(value: str) -> int:
+    normalized = value.strip().replace("-", "/").replace(".", "/")
+    try:
+        parsed = dt.datetime.strptime(normalized, "%Y/%m/%d")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"Invalid date '{value}'. Use YYYY/MM/DD."
+        ) from exc
+    return int(parsed.timestamp())
+
+
+def format_ts(value: float | int | None) -> str:
+    if not value:
+        return "0"
+    return dt.datetime.fromtimestamp(float(value)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def expand(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def load_rows(db_path: str, date_from_ts: int, date_to_ts: int) -> list[sqlite3.Row]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        sql = """
+            SELECT
+                file.file_id,
+                folder.name || "/" || file.basename || "." || file.extension AS fname,
+                file.last_modified,
+                file.displayed_count,
+                meta.exif_datetime,
+                meta.make,
+                meta.model,
+                meta.title,
+                meta.caption,
+                meta.tags
+            FROM file
+            INNER JOIN folder ON folder.folder_id = file.folder_id
+            LEFT JOIN meta ON meta.file_id = file.file_id
+            WHERE folder.missing = 0
+              AND meta.exif_datetime > ?
+              AND meta.exif_datetime < ?
+            ORDER BY meta.exif_datetime ASC, fname ASC
+        """
+        return conn.execute(sql, (date_from_ts, date_to_ts)).fetchall()
+    finally:
+        conn.close()
+
+
+def find_same_basename_elsewhere(search_root: str, missing_path: str) -> list[str]:
+    basename = os.path.basename(missing_path)
+    matches: list[str] = []
+    for root, dirs, files in os.walk(search_root):
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+        for file_name in files:
+            if file_name == basename:
+                matches.append(os.path.join(root, file_name))
+    return matches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", required=True, help="Path to pictureframe.db3")
+    parser.add_argument("--date-from", required=True, type=parse_date, help="Inclusive lower day boundary in YYYY/MM/DD")
+    parser.add_argument("--date-to", required=True, type=parse_date, help="Exclusive upper day boundary in YYYY/MM/DD")
+    parser.add_argument(
+        "--search-root",
+        help="Optional root folder to search for same basenames when cached paths are missing",
+    )
+    parser.add_argument(
+        "--show-all",
+        action="store_true",
+        help="Print every matched row, not just summary and missing files",
+    )
+    args = parser.parse_args()
+
+    db_path = expand(args.db)
+    if not os.path.exists(db_path):
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        return 2
+
+    search_root = expand(args.search_root) if args.search_root else None
+    if search_root and not os.path.isdir(search_root):
+        print(f"Search root is not a directory: {search_root}", file=sys.stderr)
+        return 2
+
+    rows = load_rows(db_path, args.date_from, args.date_to)
+    total = len(rows)
+    existing = [row for row in rows if os.path.exists(row["fname"])]
+    missing = [row for row in rows if not os.path.exists(row["fname"])]
+
+    print(f"DB: {db_path}")
+    print(f"Date range: {format_ts(args.date_from)} <= exif_datetime < {format_ts(args.date_to)}")
+    print(f"Matched rows: {total}")
+    print(f"Existing files: {len(existing)}")
+    print(f"Missing files: {len(missing)}")
+
+    if rows:
+        timestamps = Counter(int(float(row["exif_datetime"] or 0)) for row in rows)
+        duplicate_timestamps = [(ts, count) for ts, count in timestamps.items() if count > 1]
+        if duplicate_timestamps:
+            print("Duplicate exif timestamps:")
+            for ts, count in sorted(duplicate_timestamps):
+                print(f"  {format_ts(ts)} : {count} files")
+
+    if args.show_all and rows:
+        print("\nMatched rows:")
+        for row in rows:
+            state = "OK" if os.path.exists(row["fname"]) else "MISSING"
+            print(
+                f"  [{state}] file_id={row['file_id']} "
+                f"exif={format_ts(row['exif_datetime'])} "
+                f"mtime={format_ts(row['last_modified'])} "
+                f"shown={row['displayed_count']} "
+                f"path={row['fname']}"
+            )
+
+    if missing:
+        print("\nMissing files:")
+        for row in missing:
+            print(
+                f"  file_id={row['file_id']} "
+                f"exif={format_ts(row['exif_datetime'])} "
+                f"mtime={format_ts(row['last_modified'])} "
+                f"path={row['fname']}"
+            )
+            if search_root:
+                matches = find_same_basename_elsewhere(search_root, row["fname"])
+                for match in matches[:10]:
+                    print(f"    candidate={match}")
+                if len(matches) > 10:
+                    print(f"    ... {len(matches) - 10} more candidates")
+
+    if not rows:
+        print("\nNo cached photos matched this date range.")
+        print("That usually means either:")
+        print("  - the cache has very few files with EXIF date in that range")
+        print("  - those photos had no EXIF date, so Picframe used file mtime instead")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/picframe/config/configuration_example.yaml
+++ b/src/picframe/config/configuration_example.yaml
@@ -63,6 +63,11 @@ viewer:
   menu_autohide_tm: 10.0                  # default=10.0, time in seconds to show menu before auto hiding (0 disables auto hiding)
   geo_suppress_list: []                   # default=None, substrings to remove from the location text
 
+  show_progress_bar: False                # default=False, True shows a progress bar indicating time until next photo
+  progress_bar_height: 8                  # default=8, height in pixels
+  progress_bar_color: [255, 255, 255, 200] # default=[255, 255, 255, 200], RGBA color of the bar
+  progress_bar_position: "B"              # default="B" ("T", "B"), whether to display at top or bottom of screen
+
 model:
   pic_dir: "~/Pictures"                   # default="~/Pictures", root folder for images
   deleted_pictures: "~/DeletedPictures"   # move deleted pictures here

--- a/src/picframe/config/configuration_example.yaml
+++ b/src/picframe/config/configuration_example.yaml
@@ -79,7 +79,7 @@ model:
   time_delay: 200.0                       # default=200.0, time between consecutive slide starts - can be changed by MQTT
   fade_time: 10.0                         # default=10.0, change time during which slides overlap - can be changed by MQTT"
   update_interval: 2.0                    # default=2.0, time in seconds to wait between two consecutive scans for new files
-  shuffle: True                           # default=True, shuffle on reloading image files - can be changed by MQTT"
+  shuffle: True                           # default=True, rebuild playlist using a weighted random order that favors less-shown and slightly older photos while honoring recent_n - can be changed by MQTT"
   sort_cols: 'fname ASC'                  # default='fname ASC' can be any columns in the table with optional ASC or DESC separated by commas
                                           # fname, last_modified, file_id, orientation, exif_datetime, f_number,
                                           # exposure_time, iso, focal_length, make, model, lens, rating,

--- a/src/picframe/controller.py
+++ b/src/picframe/controller.py
@@ -298,6 +298,22 @@ class Controller:
         (pic, _) = self.__model.get_current_pics()
         return pic.fname
 
+    def get_queue_snapshot(self, limit=8):
+        return self.__model.get_queue_snapshot(limit=limit)
+
+    def get_queue_thumb_source(self, index):
+        return self.__model.get_queue_thumb_source(index)
+
+    def jump_to_queue_index(self, index):
+        success, reason = self.__model.set_next_file_index(index)
+        if success:
+            if self.__viewer.is_video_playing():
+                self.__viewer.stop_video()
+            self.__next_tm = 0
+            self.__force_navigate = True
+            self.__viewer.reset_name_tm()
+        return {"ok": success, "reason": reason}
+
     def loop(self):  # TODO exit loop gracefully and call image_cache.stop()
         # catch ctrl-c
         signal.signal(signal.SIGINT, self.__signal_handler)

--- a/src/picframe/controller.py
+++ b/src/picframe/controller.py
@@ -328,6 +328,7 @@ class Controller:
                             field_name = self.__model.EXIF_TO_FIELD[key]
                             image_attr[key] = pics[0].__dict__[field_name]  # TODO nicer using namedtuple for Pic
                     if self.__mqtt_config['use_mqtt']:
+                        image_attr['times_shown'] = pics[0].displayed_count + 1
                         self.publish_state(pics[0].fname, image_attr)
             self.__model.pause_looping = self.__viewer.is_in_transition()
             (loop_running, skip_image, video_playing) = self.__viewer.slideshow_is_running(pics, time_delay, fade_time, self.__paused)

--- a/src/picframe/html/index.html
+++ b/src/picframe/html/index.html
@@ -51,6 +51,18 @@
             <a href="/current_image_original" class="original-link">original</a>
         </section>
 
+        <section class="card queue-card" id="queue-card">
+            <div class="queue-card__header">
+                <div>
+                    <div class="card-title">Queue</div>
+                    <div class="queue-card__summary" id="queue-summary">Loading queue...</div>
+                </div>
+                <div class="queue-card__meta" id="queue-meta"></div>
+            </div>
+            <div class="queue-card__current" id="queue-current"></div>
+            <div class="queue-list" id="queue-list"></div>
+        </section>
+
         <div id="controls">
             <!-- Display (without display_is_on, which is in header) -->
             {% for group in groups if group.key == "display" %}

--- a/src/picframe/html/index.html
+++ b/src/picframe/html/index.html
@@ -1,54 +1,62 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <meta name="viewport" content="width=device-width, inital-scale=1"/>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>PicFrame</title>
+    <link rel="stylesheet" href="style.css"/>
 </head>
-    <body onload="setStyle(); createSpans(); refreshData();">
-        <script type="text/javascript">
-            /* widths to use for spans. Other slots in the array could be used for other
-             things...
-            */
-            const TYPES = {"bool":[5,], "text":[15,], "date":[10,], "number":[5,], "action":[5,]};
+<body>
+    <script>
+    const ids = {
+        "back":              {type:"action", fn:"back={}",                                                val:false, group:"nav"},
+        "next":              {type:"action", fn:"next={}",                                                val:false, group:"nav"},
+        "paused":            {type:"bool",   fn:"setter",                                                 val:false, group:"nav"},
 
-            /* this is used to render the ids on this page.
-             fn is a method of controller
-             underscores will be replaced by spaces but it's also possible to use
-             an alternative "desc":"..." field
-            */
-            const ids = {
-                "back": {type:"action", fn:"back={}", val:false},
-                "next": {type:"action", fn:"next={}", val:false},
-                "paused": {type:"bool", fn:"setter", val:false},
-                "display_is_on": {type:"bool", fn:"setter", val:false},
-                "shuffle": {type:"bool", fn:"setter", val:false},
-                "text_name": {type:"bool", fn:"set_show_text={\"txt_key\":\"name\",\"val\":$val}", val:false},
-                "text_date": {type:"bool", fn:"set_show_text={\"txt_key\":\"date\",\"val\":$val}", val:false},
-                "text_folder": {type:"bool", fn:"set_show_text={\"txt_key\":\"folder\",\"val\":$val}", val:false},
-                "text_location": {type:"bool", fn:"set_show_text={\"txt_key\":\"location\",\"val\":$val}", val:false},
-                "clear_text": {type:"action", fn:"set_show_text={}", val:false},
-                "refresh_show_text": {type:"action", fn:"refresh_show_text={}", val:false},
+        "display_is_on":     {type:"bool",   fn:"setter",                                                 val:false, group:"display"},
+        "shuffle":           {type:"bool",   fn:"setter",                                                 val:false, group:"display"},
+        "brightness":        {type:"number", fn:"setter",                                                 val:0,     group:"display"},
+        "fade_time":         {type:"number", fn:"setter",                                                 val:0,     group:"display"},
+        "time_delay":        {type:"number", fn:"setter",                                                 val:0,     group:"display"},
 
-                "date_from": {type:"date", fn:"setter", val:0},
-                "date_to": {type:"date", fn:"setter", val:0},
-                "fade_time": {type:"number", fn:"setter", val:0},
-                "time_delay": {type:"number", fn:"setter", val:0},
-                "brightness": {type:"number", fn:"setter", val:0},
-                "subdirectory": {type:"text", fn:"setter", val:""},
-                "location_filter": {type:"text", fn:"setter", val:""},
-                "tags_filter": {type:"text", fn:"setter", val:""},
-                "delete": {type:"action", fn:"delete={}", val:false},
-                "purge_files": {type:"action", fn:"purge_files={}", val:false},
-                "stop": {type:"action", fn:"stop={}", val:false},
-                };
-        </script>
-        <script type="text/javascript" src="pf_functions.js"></script>
-        <h1>Simple Picture Frame page</h1>
-        <div id="spans">
+        "text_name":         {type:"bool",   fn:"set_show_text={\"txt_key\":\"name\",\"val\":$val}",     val:false, group:"text"},
+        "text_date":         {type:"bool",   fn:"set_show_text={\"txt_key\":\"date\",\"val\":$val}",     val:false, group:"text"},
+        "text_folder":       {type:"bool",   fn:"set_show_text={\"txt_key\":\"folder\",\"val\":$val}",   val:false, group:"text"},
+        "text_location":     {type:"bool",   fn:"set_show_text={\"txt_key\":\"location\",\"val\":$val}", val:false, group:"text"},
+        "clear_text":        {type:"action", fn:"set_show_text={}",                                       val:false, group:"text"},
+        "refresh_show_text": {type:"action", fn:"refresh_show_text={}",                                   val:false, group:"text"},
+
+        "date_from":         {type:"date",   fn:"setter",                                                 val:0,     group:"filter"},
+        "date_to":           {type:"date",   fn:"setter",                                                 val:0,     group:"filter"},
+        "subdirectory":      {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
+        "location_filter":   {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
+        "tags_filter":       {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
+
+        "delete":            {type:"action", fn:"delete={}",                                              val:false, group:"actions"},
+        "purge_files":       {type:"action", fn:"purge_files={}",                                         val:false, group:"actions"},
+        "stop":              {type:"action", fn:"stop={}",                                                val:false, group:"actions"},
+    };
+    </script>
+
+    <header>
+        <h1>PicFrame</h1>
+    </header>
+
+    <main>
+        <section class="preview-section">
+            <a href="/current_image">
+                <img id="preview-img" src="/current_image" alt="Current image" onerror="this.style.visibility='hidden'"/>
+            </a>
+            <a href="/current_image_original" class="original-link">original</a>
+        </section>
+
+        <div id="controls"></div>
+
+        <div class="update-row">
+            <button id="upload_button" onclick="uploadValues()">Apply Changes</button>
         </div>
-        <button id="upload_button" onclick="uploadValues()">UPDATE</button>
-        <a href="/current_image">See the current image</a>
-        or <a href="/current_image_original">its unmodified original</a>
-        (use browser BACK to return to this page)
-    </body>
+    </main>
+
+    <script src="pf_functions.js"></script>
+</body>
 </html>

--- a/src/picframe/html/index.html
+++ b/src/picframe/html/index.html
@@ -31,24 +31,24 @@
                         <img id="preview-img" src="/current_image" alt="Current image" onerror="this.style.visibility='hidden'"/>
                     </a>
                 </div>
+
+                <!-- Nav overlay on image -->
+                {% for group in groups if group.key == "nav" %}
+                    {% for ctrl in group.controls if ctrl.id == "back" %}
+                        <button class="nav-overlay nav-overlay--left pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Back">&#9665;</button>
+                    {% endfor %}
+                    {% for ctrl in group.controls if ctrl.id == "next" %}
+                        <button class="nav-overlay nav-overlay--right pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Next">&#9655;</button>
+                    {% endfor %}
+                    {% for ctrl in group.controls if ctrl.id == "paused" %}
+                        {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                        <button class="nav-overlay nav-overlay--pause {{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">
+                            {{ "&#9646;&#9646; Paused" if ctrl.val else "&#9654; Playing" }}
+                        </button>
+                    {% endfor %}
+                {% endfor %}
             </div>
             <a href="/current_image_original" class="original-link">original</a>
-
-            <!-- Nav overlay on image -->
-            {% for group in groups if group.key == "nav" %}
-                {% for ctrl in group.controls if ctrl.id == "back" %}
-                    <button class="nav-overlay nav-overlay--left pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Back">&#9665;</button>
-                {% endfor %}
-                {% for ctrl in group.controls if ctrl.id == "next" %}
-                    <button class="nav-overlay nav-overlay--right pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Next">&#9655;</button>
-                {% endfor %}
-                {% for ctrl in group.controls if ctrl.id == "paused" %}
-                    {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
-                    <button class="nav-overlay nav-overlay--pause {{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">
-                        {{ "&#9646;&#9646; Paused" if ctrl.val else "&#9654; Playing" }}
-                    </button>
-                {% endfor %}
-            {% endfor %}
         </section>
 
         <div id="controls">

--- a/src/picframe/html/index.html
+++ b/src/picframe/html/index.html
@@ -7,36 +7,7 @@
     <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
-    <script>
-    const ids = {
-        "back":              {type:"action", fn:"back={}",                                                val:false, group:"nav"},
-        "next":              {type:"action", fn:"next={}",                                                val:false, group:"nav"},
-        "paused":            {type:"bool",   fn:"setter",                                                 val:false, group:"nav"},
-
-        "display_is_on":     {type:"bool",   fn:"setter",                                                 val:false, group:"display"},
-        "shuffle":           {type:"bool",   fn:"setter",                                                 val:false, group:"display"},
-        "brightness":        {type:"number", fn:"setter",                                                 val:0,     group:"display"},
-        "fade_time":         {type:"number", fn:"setter",                                                 val:0,     group:"display"},
-        "time_delay":        {type:"number", fn:"setter",                                                 val:0,     group:"display"},
-
-        "text_name":         {type:"bool",   fn:"set_show_text={\"txt_key\":\"name\",\"val\":$val}",     val:false, group:"text"},
-        "text_date":         {type:"bool",   fn:"set_show_text={\"txt_key\":\"date\",\"val\":$val}",     val:false, group:"text"},
-        "text_folder":       {type:"bool",   fn:"set_show_text={\"txt_key\":\"folder\",\"val\":$val}",   val:false, group:"text"},
-        "text_location":     {type:"bool",   fn:"set_show_text={\"txt_key\":\"location\",\"val\":$val}", val:false, group:"text"},
-        "clear_text":        {type:"action", fn:"set_show_text={}",                                       val:false, group:"text"},
-        "refresh_show_text": {type:"action", fn:"refresh_show_text={}",                                   val:false, group:"text"},
-
-        "date_from":         {type:"date",   fn:"setter",                                                 val:0,     group:"filter"},
-        "date_to":           {type:"date",   fn:"setter",                                                 val:0,     group:"filter"},
-        "subdirectory":      {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
-        "location_filter":   {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
-        "tags_filter":       {type:"text",   fn:"setter",                                                 val:"",    group:"filter"},
-
-        "delete":            {type:"action", fn:"delete={}",                                              val:false, group:"actions"},
-        "purge_files":       {type:"action", fn:"purge_files={}",                                         val:false, group:"actions"},
-        "stop":              {type:"action", fn:"stop={}",                                                val:false, group:"actions"},
-    };
-    </script>
+    <script>const ids = {{ ids_json }};</script>
 
     <header>
         <h1>PicFrame</h1>
@@ -50,7 +21,38 @@
             <a href="/current_image_original" class="original-link">original</a>
         </section>
 
-        <div id="controls"></div>
+        <div id="controls">
+            {% for group in groups %}
+            <div class="card{% if group.danger %} card--danger{% endif %}">
+                <div class="card-title">{{ group.label }}</div>
+                <div class="card-body">
+                    {% for ctrl in group.controls %}
+                    {% if ctrl.type in ("bool", "action") %}
+                        {% if ctrl.type == "bool" %}
+                            {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                        {% elif group.danger %}
+                            {% set btn_class = "pf-btn pf-btn--danger" %}
+                        {% else %}
+                            {% set btn_class = "pf-btn pf-btn--action" %}
+                        {% endif %}
+                        <button class="{{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
+                    {% else %}
+                        <div class="pf-field{% if ctrl.type == 'text' %} pf-field--wide{% endif %}">
+                            <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
+                            {% if ctrl.type == "number" %}
+                                <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:5ch">
+                            {% elif ctrl.type == "date" %}
+                                <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:10ch">
+                            {% else %}
+                                <input id="{{ ctrl.id }}" type="text" value="{{ ctrl.val }}">
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
 
         <div class="update-row">
             <button id="upload_button" onclick="uploadValues()">Apply Changes</button>

--- a/src/picframe/html/index.html
+++ b/src/picframe/html/index.html
@@ -10,44 +10,126 @@
     <script>const ids = {{ ids_json }};</script>
 
     <header>
-        <h1>PicFrame</h1>
+        <span class="header-title">PicFrame</span>
+        {% for group in groups if group.key == "display" %}
+            {% for ctrl in group.controls if ctrl.id == "display_is_on" %}
+                {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                <button class="header-power {{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">
+                    <span class="power-icon">&#9679;</span>
+                    <span class="power-label">{{ "ON" if ctrl.val else "OFF" }}</span>
+                </button>
+            {% endfor %}
+        {% endfor %}
     </header>
 
     <main>
-        <section class="preview-section">
-            <a href="/current_image">
-                <img id="preview-img" src="/current_image" alt="Current image" onerror="this.style.visibility='hidden'"/>
-            </a>
+        <!-- Photo with frame -->
+        <section class="frame-wrapper">
+            <div class="frame">
+                <div class="frame-mat">
+                    <a href="/current_image" class="frame-img-link">
+                        <img id="preview-img" src="/current_image" alt="Current image" onerror="this.style.visibility='hidden'"/>
+                    </a>
+                </div>
+            </div>
             <a href="/current_image_original" class="original-link">original</a>
+
+            <!-- Nav overlay on image -->
+            {% for group in groups if group.key == "nav" %}
+                {% for ctrl in group.controls if ctrl.id == "back" %}
+                    <button class="nav-overlay nav-overlay--left pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Back">&#9665;</button>
+                {% endfor %}
+                {% for ctrl in group.controls if ctrl.id == "next" %}
+                    <button class="nav-overlay nav-overlay--right pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')" aria-label="Next">&#9655;</button>
+                {% endfor %}
+                {% for ctrl in group.controls if ctrl.id == "paused" %}
+                    {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                    <button class="nav-overlay nav-overlay--pause {{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">
+                        {{ "&#9646;&#9646; Paused" if ctrl.val else "&#9654; Playing" }}
+                    </button>
+                {% endfor %}
+            {% endfor %}
         </section>
 
         <div id="controls">
-            {% for group in groups %}
-            <div class="card{% if group.danger %} card--danger{% endif %}">
+            <!-- Display (without display_is_on, which is in header) -->
+            {% for group in groups if group.key == "display" %}
+            <div class="card">
+                <div class="card-title">{{ group.label }}</div>
+                <div class="card-body">
+                    {% for ctrl in group.controls if ctrl.id != "display_is_on" %}
+                        {% if ctrl.type == "bool" %}
+                            {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
+                            <button class="{{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
+                        {% elif ctrl.id == "brightness" %}
+                            <div class="pf-field pf-field--slider">
+                                <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
+                                <div class="slider-row">
+                                    <input type="range" id="{{ ctrl.id }}_slider" min="0" max="100" value="{{ ctrl.val }}" oninput="document.getElementById('{{ ctrl.id }}').value=this.value">
+                                    <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:5ch" class="slider-value" oninput="document.getElementById('{{ ctrl.id }}_slider').value=this.value">
+                                </div>
+                            </div>
+                        {% else %}
+                            <div class="pf-field">
+                                <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
+                                <div class="input-with-unit">
+                                    <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:6ch">
+                                    <span class="unit">s</span>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+
+            <!-- Text Overlays -->
+            {% for group in groups if group.key == "text" %}
+            <div class="card">
                 <div class="card-title">{{ group.label }}</div>
                 <div class="card-body">
                     {% for ctrl in group.controls %}
-                    {% if ctrl.type in ("bool", "action") %}
                         {% if ctrl.type == "bool" %}
                             {% set btn_class = "pf-btn pf-btn--on" if ctrl.val else "pf-btn pf-btn--off" %}
-                        {% elif group.danger %}
-                            {% set btn_class = "pf-btn pf-btn--danger" %}
+                            <button class="{{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') | replace('text ', '') }}</button>
                         {% else %}
-                            {% set btn_class = "pf-btn pf-btn--action" %}
+                            <button class="pf-btn pf-btn--action" data-resting="pf-btn pf-btn--action" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
                         {% endif %}
-                        <button class="{{ btn_class }}" data-resting="{{ btn_class }}" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
-                    {% else %}
-                        <div class="pf-field{% if ctrl.type == 'text' %} pf-field--wide{% endif %}">
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+
+            <!-- Filters -->
+            {% for group in groups if group.key == "filter" %}
+            <div class="card">
+                <div class="card-title">{{ group.label }}</div>
+                <div class="card-body card-body--stack">
+                    <div class="filter-dates">
+                        {% for ctrl in group.controls if ctrl.type == "date" %}
+                        <div class="pf-field">
                             <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
-                            {% if ctrl.type == "number" %}
-                                <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:5ch">
-                            {% elif ctrl.type == "date" %}
-                                <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:10ch">
-                            {% else %}
-                                <input id="{{ ctrl.id }}" type="text" value="{{ ctrl.val }}">
-                            {% endif %}
+                            <input id="{{ ctrl.id }}" value="{{ ctrl.val }}" style="width:12ch">
                         </div>
-                    {% endif %}
+                        {% endfor %}
+                    </div>
+                    {% for ctrl in group.controls if ctrl.type == "text" %}
+                    <div class="pf-field pf-field--wide">
+                        <label for="{{ ctrl.id }}">{{ ctrl.id | replace('_', ' ') }}</label>
+                        <input id="{{ ctrl.id }}" type="text" value="{{ ctrl.val }}">
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+
+            <!-- Danger zone -->
+            {% for group in groups if group.key == "actions" %}
+            <div class="card card--danger">
+                <div class="card-title card-title--danger">&#9888; {{ group.label }}</div>
+                <div class="card-body">
+                    {% for ctrl in group.controls %}
+                        <button class="pf-btn pf-btn--danger" data-resting="pf-btn pf-btn--danger" id="{{ ctrl.id }}" onclick="toggle('{{ ctrl.id }}')">{{ ctrl.id | replace('_', ' ') }}</button>
                     {% endfor %}
                 </div>
             </div>

--- a/src/picframe/html/index.html
+++ b/src/picframe/html/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
-    <script>const ids = {{ ids_json }};</script>
+    <script>const ids = {{ ids | tojson }};</script>
 
     <header>
         <span class="header-title">PicFrame</span>

--- a/src/picframe/html/pf_functions.js
+++ b/src/picframe/html/pf_functions.js
@@ -1,3 +1,13 @@
+const TYPES = {"bool": 5, "text": 15, "date": 10, "number": 5, "action": 5};
+
+const GROUPS = {
+    "nav":     {label: "Navigation",    danger: false},
+    "display": {label: "Display",       danger: false},
+    "text":    {label: "Text Overlays", danger: false},
+    "filter":  {label: "Filters",       danger: false},
+    "actions": {label: "Actions",       danger: true},
+};
+
 
 async function getData() {
     const response = await fetch("/?all");
@@ -6,27 +16,48 @@ async function getData() {
 
 
 function createSpans() {
-    let span_div_html = "";
-    /* ids is defined in index.html */
-    Object.entries(ids).forEach(([element_id, element]) => {
-        let description = element_id.replace("_", " ");
-        if (element.desc !== undefined) {
-            description = element.desc;
-        }
-        if (element.type === "bool" || element.type === "action") {
-            span_div_html += `<span class="pf_span off" id=${element_id} onclick="toggle('${element_id}')">${description}</span>`
-        } else {
-            width = TYPES[element.type][0];
-            span_div_html += `<span class="pf_span">${description} <input id="${element_id}"  style="width: ${width}ch;"></span>`;
-        }
+    const grouped = {};
+    Object.entries(ids).forEach(([id, el]) => {
+        const g = el.group || "other";
+        if (!grouped[g]) grouped[g] = [];
+        grouped[g].push([id, el]);
     });
-    span_div = document.getElementById("spans");
-    span_div.innerHTML = span_div_html;
 
-    // make enter press upload button
-    span_div.addEventListener("keyup", event => {
-        if (event.keyCode === 13) { // enter key
-            event.preventDefault();
+    let html = "";
+    Object.entries(GROUPS).forEach(([groupKey, groupInfo]) => {
+        const items = grouped[groupKey];
+        if (!items || items.length === 0) return;
+
+        html += `<div class="card${groupInfo.danger ? " card--danger" : ""}">`;
+        html += `<div class="card-title">${groupInfo.label}</div>`;
+        html += `<div class="card-body">`;
+
+        items.forEach(([id, el]) => {
+            const label = (el.desc !== undefined) ? el.desc : id.replace(/_/g, " ");
+
+            if (el.type === "bool" || el.type === "action") {
+                const btnClass = el.type === "action"
+                    ? (groupInfo.danger ? "pf-btn pf-btn--danger" : "pf-btn pf-btn--action")
+                    : "pf-btn pf-btn--off";
+                html += `<button class="${btnClass}" data-resting="${btnClass}" id="${id}" onclick="toggle('${id}')">${label}</button>`;
+            } else {
+                const widthAttr = el.type === "text" ? "" : ` style="width:${TYPES[el.type]}ch"`;
+                html += `<div class="pf-field${el.type === "text" ? " pf-field--wide" : ""}">`;
+                html += `<label for="${id}">${label}</label>`;
+                html += `<input id="${id}"${widthAttr}>`;
+                html += `</div>`;
+            }
+        });
+
+        html += `</div></div>`;
+    });
+
+    const container = document.getElementById("controls");
+    container.innerHTML = html;
+
+    container.addEventListener("keyup", e => {
+        if (e.key === "Enter") {
+            e.preventDefault();
             uploadValues();
         }
     });
@@ -34,137 +65,97 @@ function createSpans() {
 
 
 function isNumeric(num) {
-    return (typeof(num) === 'number' || typeof(num) === "string" && num.trim() !== '') && !isNaN(num);
+    return (typeof num === "number" || (typeof num === "string" && num.trim() !== "")) && !isNaN(num);
 }
 
 
 function refreshPage() {
-    Object.entries(ids).forEach(([element_id, element]) => { //ids declared previous to this script in each page
-        let docElement = document.getElementById(element_id);
-        let value = element.val;
+    Object.entries(ids).forEach(([id, el]) => {
+        const elem = document.getElementById(id);
+        if (!elem) return;
+        let value = el.val;
+
         if (isNumeric(value)) {
             value = parseFloat(value);
-            if (element.type === "number") { // integer or float
-                if (Math.floor(value) !== value) { //float
-                    value = value.toFixed(2);
-                }
-            } else if (element.type === "date") {
-                date = new Date(value * 1000); // js uses ms
-                value = `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
+            if (el.type === "number") {
+                if (Math.floor(value) !== value) value = value.toFixed(2);
+            } else if (el.type === "date") {
+                const d = new Date(value * 1000);
+                value = `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`;
             }
-        } else if (element.type === "bool") {
-            if (value == true || value === "true" || value === "True" || value === "ON") {
-                value = "true";
-            } else {
-                value = "false";
-            }
+        } else if (el.type === "bool") {
+            value = (value === true || value === "true" || value === "True" || value === "ON");
         }
-        docElement.value = value; //TODO have some fields not changed by ids.val?
-        element.val = value; // reset to refreshed version TODO check this is necessary?
-        if (element.type === "bool") {
-            docElement.className = (element.val ? "pf_span on" : "pf_span off");
+
+        elem.value = value;
+        el.val = value;
+
+        if (el.type === "bool") {
+            elem.className = el.val ? "pf-btn pf-btn--on" : "pf-btn pf-btn--off";
         }
     });
 }
 
 
 function refreshData() {
-    getData().then(ret_val => {
-        let data_changed = false;
-        Object.entries(ret_val).forEach(([key, val]) => {
+    getData().then(data => {
+        let changed = false;
+        Object.entries(data).forEach(([key, val]) => {
             if (key in ids && ids[key].val != val) {
-                data_changed = true;
+                changed = true;
                 ids[key].val = val;
             }
         });
-        if (data_changed) {
-            refreshPage();
-        }
-    });
+        if (changed) refreshPage();
+    }).catch(() => {});
 }
 
 
 function repeatRefresh() {
     refreshData();
-    setTimeout(repeatRefresh, 120000); //refresh every 120s in never-ending loop - faster occasionally changes values while being edited!
+    setTimeout(repeatRefresh, 120000);
 }
 
 
 function uploadValues() {
-    let data_changed = false;
-    Object.entries(ids).forEach(([element_id, element]) => { //ids declared previous to this script in each page
-        if (element.fn === "setter" && element.type !== "bool") { // done by toggle function.
-            let docElement = document.getElementById(element_id);
-            if (docElement.value != element.val) {
-                console.log("updating:" + element_id + "->" + docElement.value + ":was:" + element.val + ":");
-                element.val = docElement.value;
-                fetch(`/?${element_id}=${docElement.value}`).then(() => data_changed = true); //TODO do we need to refresh?
+    const fetches = [];
+    Object.entries(ids).forEach(([id, el]) => {
+        if (el.fn === "setter" && el.type !== "bool") {
+            const elem = document.getElementById(id);
+            if (!elem) return;
+            if (elem.value != el.val) {
+                el.val = elem.value;
+                fetches.push(fetch(`/?${id}=${elem.value}`));
             }
         }
     });
-    if (data_changed) { //TODO - is this necessary in ids.val changed here?
-        refreshData();
+    if (fetches.length > 0) {
+        Promise.all(fetches).then(() => refreshData());
     }
 }
 
 
 function toggle(id) {
-    let element = ids[id];
-    if (element.type === "bool") { //toggle val and class
-        element.val = !(element.val);
+    const el = ids[id];
+    if (el.type === "bool") {
+        el.val = !el.val;
     }
-    let cmd = `/?${id}=${element.val}`
-    if (element.fn !== "setter") { // i.e. use fn
-        cmd = `/?${element.fn}`;
-        cmd = cmd.replace('$val', element.val);
+
+    let cmd = `/?${id}=${el.val}`;
+    if (el.fn !== "setter") {
+        cmd = `/?${el.fn}`.replace("$val", el.val);
     }
-    let docElement = document.getElementById(id);
-    let css = (element.val ? "pf_span on" : "pf_span off"); // return to this
-    docElement.className = "pf_span flash";
-    console.log(cmd);
-    fetch(cmd).then(() => afterFlash(docElement, css));
+
+    const elem = document.getElementById(id);
+    const restingClass = el.type === "bool"
+        ? (el.val ? "pf-btn pf-btn--on" : "pf-btn pf-btn--off")
+        : (elem.dataset.resting || "pf-btn pf-btn--action");
+
+    elem.className = "pf-btn pf-btn--flash";
+    fetch(cmd).then(() => { elem.className = restingClass; });
 }
 
 
-function afterFlash(element, css) {
-    element.className = css; //TODO slight time delay?
-}
-
-
-// the super slimmed down python server doesn't load style sheets from file so this is
-// done using javascript!
-function setStyle() {
-    var x = document.createElement("STYLE");
-    var t = document.createTextNode("body {\
-        background-color: black;\
-        color:rgb(94, 89, 79);\
-        font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;\
-    }\
-    button {\
-        margin: 5px;\
-        padding: 10px;\
-        border: none;\
-        border-radius: 8px;\
-        font-weight: bold;\
-    }\
-    .off {\
-        background-color: maroon;\
-        color:powderblue;\
-    }\
-    .on {\
-        background-color: olivedrab;\
-        color:rebeccapurple;\
-    }\
-    .flash {\
-        background-color: orange;\
-        color:powderblue;\
-    }\
-    .pf_span {\
-        margin: 2px;\
-        padding: 4px;\
-        border-style: solid;\
-        display: inline-block;\
-    }");
-    x.appendChild(t);
-    document.head.appendChild(x);
-}
+// Initialise
+createSpans();
+repeatRefresh();

--- a/src/picframe/html/pf_functions.js
+++ b/src/picframe/html/pf_functions.js
@@ -129,6 +129,16 @@ function toggle(id) {
         } else {
             elem.className = restingClass;
         }
+
+        // Reload preview image after navigation actions
+        if (id === "back" || id === "next") {
+            const img = document.getElementById("preview-img");
+            if (img) {
+                setTimeout(() => {
+                    img.src = "/current_image?t=" + Date.now();
+                }, 500);
+            }
+        }
     });
 }
 

--- a/src/picframe/html/pf_functions.js
+++ b/src/picframe/html/pf_functions.js
@@ -31,7 +31,26 @@ function refreshPage() {
         el.val = value;
 
         if (el.type === "bool") {
-            elem.className = el.val ? "pf-btn pf-btn--on" : "pf-btn pf-btn--off";
+            elem.className = elem.className.replace(/pf-btn--on|pf-btn--off/g, "")
+                + (el.val ? " pf-btn--on" : " pf-btn--off");
+            elem.className = elem.className.replace(/\s+/g, " ").trim();
+
+            // Update power label if it's display_is_on
+            if (id === "display_is_on") {
+                const label = elem.querySelector(".power-label");
+                if (label) label.textContent = el.val ? "ON" : "OFF";
+            }
+
+            // Update pause button text
+            if (id === "paused") {
+                elem.innerHTML = el.val ? "&#9646;&#9646; Paused" : "&#9654; Playing";
+            }
+        }
+
+        // Sync brightness slider
+        const slider = document.getElementById(id + "_slider");
+        if (slider) {
+            slider.value = value;
         }
     });
 }
@@ -87,12 +106,30 @@ function toggle(id) {
     }
 
     const elem = document.getElementById(id);
-    const restingClass = el.type === "bool"
-        ? (el.val ? "pf-btn pf-btn--on" : "pf-btn pf-btn--off")
-        : (elem.dataset.resting || "pf-btn pf-btn--action");
+    const restingClass = elem.dataset.resting || elem.className;
 
-    elem.className = "pf-btn pf-btn--flash";
-    fetch(cmd).then(() => { elem.className = restingClass; });
+    // Flash
+    const origClasses = elem.className;
+    elem.className = origClasses.replace(/pf-btn--\w+/g, "") + " pf-btn--flash";
+    elem.className = elem.className.replace(/\s+/g, " ").trim();
+
+    fetch(cmd).then(() => {
+        if (el.type === "bool") {
+            const onOff = el.val ? "pf-btn--on" : "pf-btn--off";
+            elem.className = origClasses.replace(/pf-btn--on|pf-btn--off/g, onOff);
+            elem.className = elem.className.replace(/\s+/g, " ").trim();
+
+            if (id === "display_is_on") {
+                const label = elem.querySelector(".power-label");
+                if (label) label.textContent = el.val ? "ON" : "OFF";
+            }
+            if (id === "paused") {
+                elem.innerHTML = el.val ? "&#9646;&#9646; Paused" : "&#9654; Playing";
+            }
+        } else {
+            elem.className = restingClass;
+        }
+    });
 }
 
 

--- a/src/picframe/html/pf_functions.js
+++ b/src/picframe/html/pf_functions.js
@@ -3,6 +3,113 @@ async function getData() {
     return response.json();
 }
 
+async function getQueueData() {
+    const response = await fetch("/?queue_snapshot=1");
+    return response.json();
+}
+
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function queueThumbUrl(slot) {
+    return `/?queue_thumb=${slot.slot_index}&v=${slot.thumb_version || 0}`;
+}
+
+function renderQueueSlot(slot, isCurrent = false) {
+    const pairBadge = slot.is_pair ? '<span class="queue-badge">pair</span>' : "";
+    const secondary = slot.secondary_label
+        ? `<div class="queue-item__secondary">${escapeHtml(slot.secondary_label)}</div>`
+        : "";
+    const buttonLabel = isCurrent ? "Current" : "Show Next";
+
+    return `
+        <button class="queue-item${isCurrent ? " queue-item--current" : ""}" data-queue-index="${slot.slot_index}" ${isCurrent ? "disabled" : ""}>
+            <img class="queue-item__thumb" src="${queueThumbUrl(slot)}" alt="" loading="lazy">
+            <div class="queue-item__body">
+                <div class="queue-item__title-row">
+                    <span class="queue-item__index">${slot.slot_index + 1}.</span>
+                    <span class="queue-item__title">${escapeHtml(slot.primary_label || "Unavailable")}</span>
+                    ${pairBadge}
+                </div>
+                ${secondary}
+            </div>
+            <span class="queue-item__action">${buttonLabel}</span>
+        </button>
+    `;
+}
+
+function renderQueue(snapshot) {
+    const summary = document.getElementById("queue-summary");
+    const meta = document.getElementById("queue-meta");
+    const current = document.getElementById("queue-current");
+    const list = document.getElementById("queue-list");
+
+    if (!summary || !meta || !current || !list) {
+        return;
+    }
+
+    if (!snapshot || snapshot.total_slots === 0) {
+        summary.textContent = "No queued images available";
+        meta.textContent = "";
+        current.innerHTML = "";
+        list.innerHTML = '<div class="queue-empty">Queue will appear after images are loaded.</div>';
+        return;
+    }
+
+    summary.textContent = snapshot.reload_pending ? "Queue refresh pending" : "Upcoming playlist slots";
+    if (snapshot.displayed_index === null || snapshot.displayed_index === undefined) {
+        meta.textContent = `next ${snapshot.next_index + 1} / ${snapshot.total_slots}`;
+    } else {
+        meta.textContent = `slot ${snapshot.displayed_index + 1} / ${snapshot.total_slots}`;
+    }
+
+    current.innerHTML = snapshot.current_slot
+        ? renderQueueSlot(snapshot.current_slot, true)
+        : '<div class="queue-empty">Current image will appear here after the first slide loads.</div>';
+
+    if (!snapshot.upcoming_slots || snapshot.upcoming_slots.length === 0) {
+        list.innerHTML = '<div class="queue-empty">No upcoming slots available right now.</div>';
+        return;
+    }
+
+    list.innerHTML = snapshot.upcoming_slots.map(slot => renderQueueSlot(slot)).join("");
+}
+
+async function refreshQueue() {
+    try {
+        const snapshot = await getQueueData();
+        renderQueue(snapshot);
+    } catch (_error) {
+        const list = document.getElementById("queue-list");
+        const summary = document.getElementById("queue-summary");
+        if (summary) summary.textContent = "Queue unavailable";
+        if (list) list.innerHTML = '<div class="queue-empty">Unable to load queue preview.</div>';
+    }
+}
+
+async function jumpToQueueIndex(index) {
+    const response = await fetch(`/?queue_jump=${index}`);
+    const result = await response.json();
+    if (!result.ok) {
+        await refreshQueue();
+        return;
+    }
+
+    const img = document.getElementById("preview-img");
+    setTimeout(() => {
+        if (img) {
+            img.src = "/current_image?t=" + Date.now();
+        }
+        refreshQueue();
+    }, 500);
+}
+
 
 function isNumeric(num) {
     return (typeof num === "number" || (typeof num === "string" && num.trim() !== "")) && !isNaN(num);
@@ -72,6 +179,7 @@ function refreshData() {
 
 function repeatRefresh() {
     refreshData();
+    refreshQueue();
     setTimeout(repeatRefresh, 120000);
 }
 
@@ -89,7 +197,10 @@ function uploadValues() {
         }
     });
     if (fetches.length > 0) {
-        Promise.all(fetches).then(() => refreshData());
+        Promise.all(fetches).then(() => {
+            refreshData();
+            refreshQueue();
+        });
     }
 }
 
@@ -133,11 +244,12 @@ function toggle(id) {
         // Reload preview image after navigation actions
         if (id === "back" || id === "next") {
             const img = document.getElementById("preview-img");
-            if (img) {
-                setTimeout(() => {
+            setTimeout(() => {
+                if (img) {
                     img.src = "/current_image?t=" + Date.now();
-                }, 500);
-            }
+                }
+                refreshQueue();
+            }, 500);
         }
     });
 }
@@ -145,10 +257,18 @@ function toggle(id) {
 
 // Format initial values (dates, floats) and start polling
 refreshPage();
+refreshQueue();
 repeatRefresh();
 document.getElementById("controls").addEventListener("keyup", e => {
     if (e.key === "Enter") {
         e.preventDefault();
         uploadValues();
     }
+});
+document.getElementById("queue-card").addEventListener("click", e => {
+    const button = e.target.closest("[data-queue-index]");
+    if (!button || button.disabled) {
+        return;
+    }
+    jumpToQueueIndex(button.dataset.queueIndex);
 });

--- a/src/picframe/html/pf_functions.js
+++ b/src/picframe/html/pf_functions.js
@@ -1,66 +1,6 @@
-const TYPES = {"bool": 5, "text": 15, "date": 10, "number": 5, "action": 5};
-
-const GROUPS = {
-    "nav":     {label: "Navigation",    danger: false},
-    "display": {label: "Display",       danger: false},
-    "text":    {label: "Text Overlays", danger: false},
-    "filter":  {label: "Filters",       danger: false},
-    "actions": {label: "Actions",       danger: true},
-};
-
-
 async function getData() {
     const response = await fetch("/?all");
     return response.json();
-}
-
-
-function createSpans() {
-    const grouped = {};
-    Object.entries(ids).forEach(([id, el]) => {
-        const g = el.group || "other";
-        if (!grouped[g]) grouped[g] = [];
-        grouped[g].push([id, el]);
-    });
-
-    let html = "";
-    Object.entries(GROUPS).forEach(([groupKey, groupInfo]) => {
-        const items = grouped[groupKey];
-        if (!items || items.length === 0) return;
-
-        html += `<div class="card${groupInfo.danger ? " card--danger" : ""}">`;
-        html += `<div class="card-title">${groupInfo.label}</div>`;
-        html += `<div class="card-body">`;
-
-        items.forEach(([id, el]) => {
-            const label = (el.desc !== undefined) ? el.desc : id.replace(/_/g, " ");
-
-            if (el.type === "bool" || el.type === "action") {
-                const btnClass = el.type === "action"
-                    ? (groupInfo.danger ? "pf-btn pf-btn--danger" : "pf-btn pf-btn--action")
-                    : "pf-btn pf-btn--off";
-                html += `<button class="${btnClass}" data-resting="${btnClass}" id="${id}" onclick="toggle('${id}')">${label}</button>`;
-            } else {
-                const widthAttr = el.type === "text" ? "" : ` style="width:${TYPES[el.type]}ch"`;
-                html += `<div class="pf-field${el.type === "text" ? " pf-field--wide" : ""}">`;
-                html += `<label for="${id}">${label}</label>`;
-                html += `<input id="${id}"${widthAttr}>`;
-                html += `</div>`;
-            }
-        });
-
-        html += `</div></div>`;
-    });
-
-    const container = document.getElementById("controls");
-    container.innerHTML = html;
-
-    container.addEventListener("keyup", e => {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            uploadValues();
-        }
-    });
 }
 
 
@@ -156,6 +96,12 @@ function toggle(id) {
 }
 
 
-// Initialise
-createSpans();
+// Format initial values (dates, floats) and start polling
+refreshPage();
 repeatRefresh();
+document.getElementById("controls").addEventListener("keyup", e => {
+    if (e.key === "Enter") {
+        e.preventDefault();
+        uploadValues();
+    }
+});

--- a/src/picframe/html/style.css
+++ b/src/picframe/html/style.css
@@ -269,6 +269,129 @@ main {
     align-items: stretch;
 }
 
+.queue-card {
+    padding: 16px;
+}
+
+.queue-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.queue-card__summary {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.queue-card__meta {
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+.queue-card__current {
+    margin-bottom: 10px;
+}
+
+.queue-list {
+    display: grid;
+    gap: 8px;
+}
+
+.queue-item {
+    display: grid;
+    grid-template-columns: 72px minmax(0, 1fr) auto;
+    gap: 12px;
+    align-items: center;
+    width: 100%;
+    padding: 9px 10px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: #151517;
+    color: var(--text);
+    text-align: left;
+    cursor: pointer;
+}
+
+.queue-item:disabled {
+    cursor: default;
+    opacity: 1;
+}
+
+.queue-item__thumb {
+    width: 72px;
+    height: 54px;
+    object-fit: cover;
+    border-radius: 8px;
+    background: #252528;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.queue-item__body {
+    min-width: 0;
+}
+
+.queue-item__title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.queue-item__index,
+.queue-item__action,
+.queue-item__secondary {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.queue-item__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.queue-item__secondary {
+    margin-top: 2px;
+    padding-left: 24px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.queue-item__action {
+    font-weight: 600;
+}
+
+.queue-item--current {
+    background: linear-gradient(180deg, #1f2418 0%, #171b14 100%);
+    border-color: #38492a;
+}
+
+.queue-badge {
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: rgba(10, 132, 255, 0.12);
+    color: #8cc1ff;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.queue-empty {
+    padding: 14px 12px;
+    border: 1px dashed var(--border);
+    border-radius: 10px;
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
 .filter-dates {
     display: flex;
     gap: 12px;
@@ -485,6 +608,14 @@ main {
 
     .filter-dates .pf-field input {
         width: 100%;
+    }
+
+    .queue-item {
+        grid-template-columns: 64px minmax(0, 1fr);
+    }
+
+    .queue-item__action {
+        display: none;
     }
 
     /* Sticky apply button */

--- a/src/picframe/html/style.css
+++ b/src/picframe/html/style.css
@@ -1,0 +1,256 @@
+:root {
+    --bg: #0f0f0f;
+    --bg-card: #1c1c1e;
+    --text: #e5e5ea;
+    --text-muted: #636366;
+    --accent: #0a84ff;
+    --btn-off-bg: #3a1212;
+    --btn-off-text: #ff9a9a;
+    --btn-on-bg: #1a3a1a;
+    --btn-on-text: #6ecc6e;
+    --btn-flash-bg: #b86000;
+    --btn-flash-text: #fff;
+    --btn-action-bg: #2c2c2e;
+    --btn-action-text: #c8c4bc;
+    --border: #2c2c2e;
+    --radius: 12px;
+    --gap: 12px;
+    --input-bg: #111;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.4;
+    min-height: 100vh;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+header {
+    padding: 14px 16px 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--text);
+}
+
+main {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+}
+
+/* ── Preview ── */
+
+.preview-section {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: #000;
+    aspect-ratio: 4 / 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.preview-section a:first-child {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.preview-section img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+}
+
+.original-link {
+    position: absolute;
+    bottom: 8px;
+    right: 10px;
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.55);
+    background: rgba(0, 0, 0, 0.55);
+    padding: 3px 9px;
+    border-radius: 20px;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+.original-link:hover {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+/* ── Cards ── */
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 13px 14px;
+}
+
+.card--danger {
+    border-color: #3a1212;
+}
+
+.card-title {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+}
+
+.card-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: flex-end;
+}
+
+/* ── Buttons ── */
+
+.pf-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 14px;
+    min-height: 40px;
+    border: none;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.1s;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    white-space: nowrap;
+    text-transform: capitalize;
+}
+
+.pf-btn:active {
+    opacity: 0.75;
+}
+
+.pf-btn--off,
+.pf-btn--danger {
+    background: var(--btn-off-bg);
+    color: var(--btn-off-text);
+}
+
+.pf-btn--on {
+    background: var(--btn-on-bg);
+    color: var(--btn-on-text);
+}
+
+.pf-btn--flash {
+    background: var(--btn-flash-bg);
+    color: var(--btn-flash-text);
+}
+
+.pf-btn--action {
+    background: var(--btn-action-bg);
+    color: var(--btn-action-text);
+    border: 1px solid var(--border);
+}
+
+/* ── Input fields ── */
+
+.pf-field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.pf-field--wide {
+    flex: 1;
+    min-width: 160px;
+}
+
+.pf-field label {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: capitalize;
+}
+
+.pf-field input {
+    background: var(--input-bg);
+    border: 1px solid #333;
+    border-radius: 7px;
+    color: var(--text);
+    font-size: 13px;
+    padding: 8px 10px;
+    min-height: 36px;
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+.pf-field--wide input {
+    width: 100%;
+}
+
+.pf-field input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+/* ── Update button ── */
+
+.update-row {
+    display: flex;
+    justify-content: flex-end;
+    padding-bottom: 8px;
+}
+
+#upload_button {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 10px;
+    padding: 11px 28px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    min-height: 44px;
+    -webkit-tap-highlight-color: transparent;
+}
+
+#upload_button:active {
+    opacity: 0.8;
+}
+
+/* ── Responsive ── */
+
+@media (max-width: 380px) {
+    main {
+        padding: 10px 12px;
+        gap: 10px;
+    }
+    .card {
+        padding: 11px 12px;
+    }
+}

--- a/src/picframe/html/style.css
+++ b/src/picframe/html/style.css
@@ -100,6 +100,7 @@ main {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: var(--gap);
+    align-items: start;
 }
 
 /* ── Photo Frame (Mat + Border style) ── */
@@ -112,6 +113,7 @@ main {
 }
 
 .frame {
+    position: relative;
     background: linear-gradient(145deg, #3d3225, #1e1810, #2a2018);
     padding: 4px;
     border-radius: 3px;
@@ -373,19 +375,19 @@ main {
 
 .slider-row input[type="range"] {
     flex: 1;
-    height: 4px;
+    height: 6px;
     -webkit-appearance: none;
     appearance: none;
-    background: #333;
-    border-radius: 2px;
+    background: #444;
+    border-radius: 3px;
     outline: none;
 }
 
 .slider-row input[type="range"]::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 18px;
-    height: 18px;
+    width: 22px;
+    height: 22px;
     border-radius: 50%;
     background: var(--accent);
     cursor: pointer;
@@ -393,8 +395,8 @@ main {
 }
 
 .slider-row input[type="range"]::-moz-range-thumb {
-    width: 18px;
-    height: 18px;
+    width: 22px;
+    height: 22px;
     border-radius: 50%;
     background: var(--accent);
     cursor: pointer;

--- a/src/picframe/html/style.css
+++ b/src/picframe/html/style.css
@@ -14,7 +14,7 @@
     --btn-action-text: #c8c4bc;
     --border: #2c2c2e;
     --radius: 12px;
-    --gap: 12px;
+    --gap: 20px;
     --input-bg: #111;
 }
 
@@ -39,7 +39,7 @@ a {
 }
 
 header {
-    padding: 14px 16px 12px;
+    padding: 14px 24px 12px;
     border-bottom: 1px solid var(--border);
 }
 
@@ -51,11 +51,17 @@ header h1 {
 }
 
 main {
-    max-width: 600px;
+    max-width: 1200px;
     margin: 0 auto;
-    padding: 14px 16px;
+    padding: 20px 24px;
     display: flex;
     flex-direction: column;
+    gap: var(--gap);
+}
+
+#controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
     gap: var(--gap);
 }
 
@@ -67,6 +73,7 @@ main {
     overflow: hidden;
     background: #000;
     aspect-ratio: 4 / 3;
+    max-height: 520px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -245,10 +252,13 @@ main {
 
 /* ── Responsive ── */
 
-@media (max-width: 380px) {
+@media (max-width: 500px) {
     main {
-        padding: 10px 12px;
-        gap: 10px;
+        padding: 12px;
+        gap: 12px;
+    }
+    #controls {
+        grid-template-columns: 1fr;
     }
     .card {
         padding: 11px 12px;

--- a/src/picframe/html/style.css
+++ b/src/picframe/html/style.css
@@ -16,6 +16,9 @@
     --radius: 12px;
     --gap: 20px;
     --input-bg: #111;
+    --frame-outer: #2a2018;
+    --frame-mat: #e8e0d4;
+    --danger-border: #5a2020;
 }
 
 * {
@@ -38,22 +41,56 @@ a {
     text-decoration: none;
 }
 
+/* ── Header ── */
+
 header {
-    padding: 14px 24px 12px;
+    padding: 12px 24px;
     border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
-header h1 {
+.header-title {
     font-size: 17px;
     font-weight: 600;
     letter-spacing: 0.02em;
     color: var(--text);
 }
 
+.header-power {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: none;
+    border-radius: 20px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.1s;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.header-power:active {
+    opacity: 0.75;
+}
+
+.power-icon {
+    font-size: 10px;
+}
+
+.power-label {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+/* ── Main layout ── */
+
 main {
-    max-width: 1200px;
+    max-width: 1100px;
     margin: 0 auto;
-    padding: 20px 24px;
+    padding: 24px 24px 100px;
     display: flex;
     flex-direction: column;
     gap: var(--gap);
@@ -61,52 +98,134 @@ main {
 
 #controls {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
     gap: var(--gap);
 }
 
-/* ── Preview ── */
+/* ── Photo Frame (Mat + Border style) ── */
 
-.preview-section {
+.frame-wrapper {
     position: relative;
-    border-radius: var(--radius);
-    overflow: hidden;
-    background: #000;
-    aspect-ratio: 4 / 3;
-    max-height: 520px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.frame {
+    background: linear-gradient(145deg, #3d3225, #1e1810, #2a2018);
+    padding: 4px;
+    border-radius: 3px;
+    box-shadow:
+        0 4px 20px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    max-width: 100%;
+}
+
+.frame-mat {
+    background: var(--frame-mat);
+    padding: 14px;
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-.preview-section a:first-child {
+.frame-img-link {
     display: block;
-    width: 100%;
-    height: 100%;
+    line-height: 0;
 }
 
-.preview-section img {
-    width: 100%;
-    height: 100%;
+.frame-img-link img {
+    max-width: 100%;
+    max-height: 480px;
     object-fit: contain;
     display: block;
 }
 
 .original-link {
-    position: absolute;
-    bottom: 8px;
-    right: 10px;
+    display: inline-block;
+    margin-top: 8px;
     font-size: 11px;
-    color: rgba(255, 255, 255, 0.55);
-    background: rgba(0, 0, 0, 0.55);
-    padding: 3px 9px;
+    color: var(--text-muted);
+    padding: 3px 10px;
     border-radius: 20px;
-    backdrop-filter: blur(6px);
-    -webkit-backdrop-filter: blur(6px);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    transition: color 0.15s;
 }
 
 .original-link:hover {
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--text);
+}
+
+/* ── Navigation overlays ── */
+
+.nav-overlay {
+    position: absolute;
+    border: none;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: opacity 0.15s, background 0.15s;
+    z-index: 2;
+}
+
+.nav-overlay--left,
+.nav-overlay--right {
+    top: 50%;
+    transform: translateY(-50%);
+    width: 44px;
+    height: 64px;
+    border-radius: 8px;
+    font-size: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(30, 30, 30, 0.7);
+    color: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+}
+
+.nav-overlay--left {
+    left: 8px;
+}
+
+.nav-overlay--right {
+    right: 8px;
+}
+
+.nav-overlay--left:hover,
+.nav-overlay--right:hover {
+    background: rgba(50, 50, 50, 0.85);
+    color: #fff;
+}
+
+.nav-overlay--pause {
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 500;
+    background: rgba(20, 20, 20, 0.75);
+    color: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    white-space: nowrap;
+}
+
+.nav-overlay--pause.pf-btn--on {
+    background: rgba(60, 30, 10, 0.8);
+    color: #ffb060;
+}
+
+.nav-overlay--pause.pf-btn--off {
+    background: rgba(20, 50, 20, 0.75);
+    color: #6ecc6e;
+}
+
+.nav-overlay--pause:hover {
+    opacity: 0.9;
 }
 
 /* ── Cards ── */
@@ -115,11 +234,12 @@ main {
     background: var(--bg-card);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 13px 14px;
+    padding: 14px 16px;
 }
 
 .card--danger {
-    border-color: #3a1212;
+    border-color: var(--danger-border);
+    background: linear-gradient(180deg, #1c1c1e 0%, #1a1214 100%);
 }
 
 .card-title {
@@ -128,7 +248,11 @@ main {
     letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--text-muted);
-    margin-bottom: 10px;
+    margin-bottom: 12px;
+}
+
+.card-title--danger {
+    color: #cc5555;
 }
 
 .card-body {
@@ -136,6 +260,16 @@ main {
     flex-wrap: wrap;
     gap: 8px;
     align-items: flex-end;
+}
+
+.card-body--stack {
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.filter-dates {
+    display: flex;
+    gap: 12px;
 }
 
 /* ── Buttons ── */
@@ -193,8 +327,12 @@ main {
 }
 
 .pf-field--wide {
+    width: 100%;
+}
+
+.pf-field--slider {
     flex: 1;
-    min-width: 160px;
+    min-width: 180px;
 }
 
 .pf-field label {
@@ -225,6 +363,62 @@ main {
     border-color: var(--accent);
 }
 
+/* ── Slider ── */
+
+.slider-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.slider-row input[type="range"] {
+    flex: 1;
+    height: 4px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #333;
+    border-radius: 2px;
+    outline: none;
+}
+
+.slider-row input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+    border: 2px solid var(--bg);
+}
+
+.slider-row input[type="range"]::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+    border: 2px solid var(--bg);
+}
+
+.slider-value {
+    text-align: center;
+    min-width: 5ch;
+}
+
+/* ── Input with unit suffix ── */
+
+.input-with-unit {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.input-with-unit .unit {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
 /* ── Update button ── */
 
 .update-row {
@@ -244,6 +438,7 @@ main {
     cursor: pointer;
     min-height: 44px;
     -webkit-tap-highlight-color: transparent;
+    transition: opacity 0.1s;
 }
 
 #upload_button:active {
@@ -252,15 +447,69 @@ main {
 
 /* ── Responsive ── */
 
-@media (max-width: 500px) {
+@media (max-width: 768px) {
     main {
-        padding: 12px;
-        gap: 12px;
+        padding: 16px 12px 90px;
+        gap: 14px;
     }
+
     #controls {
         grid-template-columns: 1fr;
     }
+
     .card {
-        padding: 11px 12px;
+        padding: 12px;
+    }
+
+    .frame-mat {
+        padding: 10px;
+    }
+
+    .frame-img-link img {
+        max-height: 360px;
+    }
+
+    .nav-overlay--left,
+    .nav-overlay--right {
+        width: 38px;
+        height: 52px;
+        font-size: 18px;
+    }
+
+    .filter-dates {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .filter-dates .pf-field input {
+        width: 100%;
+    }
+
+    /* Sticky apply button */
+    .update-row {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: var(--bg-card);
+        border-top: 1px solid var(--border);
+        padding: 12px 16px;
+        justify-content: stretch;
+        z-index: 10;
+    }
+
+    #upload_button {
+        width: 100%;
+    }
+}
+
+@media (max-width: 380px) {
+    .frame-mat {
+        padding: 6px;
+    }
+
+    .pf-btn {
+        padding: 7px 10px;
+        font-size: 12px;
     }
 }

--- a/src/picframe/image_cache.py
+++ b/src/picframe/image_cache.py
@@ -268,6 +268,12 @@ class ImageCache:
             waittime - starttime, now - waittime)
         return row  # NB if select fails (i.e. moved file) will return None
 
+    def get_file_info_readonly(self, file_id):
+        if not file_id:
+            return None
+        sql = "SELECT * FROM all_data WHERE file_id = ?"
+        return self.__db.execute(sql, (file_id,)).fetchone()
+
     def get_column_names(self):
         sql = "PRAGMA table_info(all_data)"
         rows = self.__db.execute(sql).fetchall()

--- a/src/picframe/image_cache.py
+++ b/src/picframe/image_cache.py
@@ -3,8 +3,66 @@ import os
 import time
 import logging
 import threading
+import random
+import math
 from picframe import get_image_meta
 from picframe.video_streamer import VIDEO_EXTENSIONS, get_video_info
+
+SHUFFLE_COUNT_ALPHA = 1.5
+SHUFFLE_AGE_BONUS = 0.3
+
+
+def _row_value(row, key, default=None):
+    return row[key] if row[key] is not None else default
+
+
+def _weighted_shuffle_partition(rows):
+    if not rows:
+        return []
+
+    last_modified_values = [float(_row_value(row, "last_modified", 0.0)) for row in rows]
+    newest = max(last_modified_values)
+    oldest = min(last_modified_values)
+    age_span = newest - oldest
+    weighted_rows = []
+
+    for row in rows:
+        displayed_count = max(0, int(_row_value(row, "displayed_count", 0)))
+        count_weight = 1.0 / math.pow(displayed_count + 1, SHUFFLE_COUNT_ALPHA)
+
+        if age_span > 0:
+            # Normalize age within this partition only. Older photos get a bounded
+            # bonus instead of dominating the selection outright.
+            age_position = (newest - float(_row_value(row, "last_modified", 0.0))) / age_span
+        else:
+            age_position = 0.0
+        age_weight = 1.0 + (SHUFFLE_AGE_BONUS * age_position)
+        total_weight = count_weight * age_weight
+
+        # Draw an exponential race priority so the final sorted order is random,
+        # but rows with higher weights tend to appear earlier in the playlist.
+        priority = -math.log(max(random.random(), 1e-12)) / total_weight
+        weighted_rows.append((priority, row))
+
+    weighted_rows.sort(key=lambda item: item[0])
+    return [row for _, row in weighted_rows]
+
+
+def weighted_shuffle_rows(rows, recent_cutoff=None):
+    if recent_cutoff is None:
+        return _weighted_shuffle_partition(list(rows))
+
+    recent_rows = []
+    older_rows = []
+    for row in rows:
+        if float(_row_value(row, "last_modified", 0.0)) >= recent_cutoff:
+            recent_rows.append(row)
+        else:
+            older_rows.append(row)
+
+    # Preserve the existing "recent first" behavior, but randomize fairly within
+    # each partition instead of hard-sorting by displayed_count.
+    return _weighted_shuffle_partition(recent_rows) + _weighted_shuffle_partition(older_rows)
 
 
 class ImageCache:
@@ -144,6 +202,42 @@ class ImageCache:
                             skip_portrait_slot = True
                         newlist.append(elem)
                 return newlist
+        except Exception:
+            return []
+
+    def query_cache_shuffle(self, where_clause, recent_cutoff=None):
+        cursor = self.__db.cursor()
+        cursor.row_factory = sqlite3.Row
+        try:
+            sql = """SELECT file_id, displayed_count, last_modified, is_portrait
+                FROM all_data WHERE {0}
+                """.format(where_clause)
+            rows = cursor.execute(sql).fetchall()
+            ordered_rows = weighted_shuffle_rows(rows, recent_cutoff=recent_cutoff)
+
+            if not self.__portrait_pairs:
+                return [(row["file_id"],) for row in ordered_rows]
+
+            portrait_rows = [row for row in ordered_rows if row["is_portrait"] == 1]
+            # Reuse the existing portrait-slot layout: the full pass determines
+            # where portrait slots exist, then portraits are consumed in the same weighted order.
+            full_list = [(-1,) if row["is_portrait"] == 1 else (row["file_id"],) for row in ordered_rows]
+            pair_list = [(row["file_id"],) for row in portrait_rows]
+            newlist = []
+            skip_portrait_slot = False
+            for i in range(len(full_list)):
+                if full_list[i][0] != -1:
+                    newlist.append(full_list[i])
+                elif skip_portrait_slot:
+                    skip_portrait_slot = False
+                    continue
+                elif pair_list:
+                    elem = pair_list.pop(0)
+                    if pair_list:
+                        elem += pair_list.pop(0)
+                        skip_portrait_slot = True
+                    newlist.append(elem)
+            return newlist
         except Exception:
             return []
 

--- a/src/picframe/image_cache.py
+++ b/src/picframe/image_cache.py
@@ -40,7 +40,7 @@ class ImageCache:
         self.__db = self.__create_open_db(self.__db_file)
         self.__db_write_lock = threading.Lock()  # lock to serialize db writes between threads
         # NB this is where the required schema is set
-        self.__update_schema(3)
+        self.__update_schema(4)
 
         self.__keep_looping = True
         self.__pause_looping = False
@@ -262,6 +262,7 @@ class ImageCache:
             SELECT
                 folder.name || "/" || file.basename || "." || file.extension AS fname,
                 file.last_modified,
+                file.displayed_count,
                 meta.*,
                 meta.height > meta.width as is_portrait,
                 location.description as location
@@ -343,6 +344,30 @@ class ImageCache:
                 # Add "displayed statistics" fields to the file table (useful for slideshow debugging)
                 self.__db.execute("ALTER TABLE file ADD COLUMN displayed_count INTEGER default 0 NOT NULL")
                 self.__db.execute("ALTER TABLE file ADD COLUMN last_displayed REAL DEFAULT 0 NOT NULL")
+
+            if schema_version <= 3:
+                # Migrate to db schema v4
+                # Expose displayed_count in the all_data view so it reaches the Pic data class and MQTT
+                self.__db.execute("DROP VIEW all_data")
+                self.__db.execute("""
+                    CREATE VIEW IF NOT EXISTS all_data
+                    AS
+                    SELECT
+                        folder.name || "/" || file.basename || "." || file.extension AS fname,
+                        file.last_modified,
+                        file.displayed_count,
+                        meta.*,
+                        meta.height > meta.width as is_portrait,
+                        location.description as location
+                    FROM file
+                        INNER JOIN folder
+                            ON folder.folder_id = file.folder_id
+                        LEFT JOIN meta
+                            ON file.file_id = meta.file_id
+                        LEFT JOIN location
+                            ON location.latitude = meta.latitude AND location.longitude = meta.longitude
+                    WHERE folder.missing = 0
+                """)
 
             # Finally, update the db's schema version stamp to the app's requested version
             self.__db.execute('DELETE FROM db_info')

--- a/src/picframe/interface_http.py
+++ b/src/picframe/interface_http.py
@@ -8,7 +8,8 @@ import json
 import threading
 import base64
 import io
-from PIL import Image
+from collections import OrderedDict
+from PIL import Image, ImageOps
 
 try:
     from http.server import BaseHTTPRequestHandler, HTTPServer  # py3
@@ -25,6 +26,10 @@ except ImportError:
     register_heif_opener = None
 
 EXTENSIONS = [".jpg", ".jpeg", ".png"]
+QUEUE_PREVIEW_LIMIT = 8
+QUEUE_THUMB_SIZE = (112, 84)
+THUMB_CACHE_SIZE = 24
+THUMB_RESAMPLE = getattr(getattr(Image, "Resampling", Image), "LANCZOS")
 EXTENSION_TO_MIMETYPE = {
     # Videos
     '.mp4': 'video/mp4',
@@ -232,11 +237,31 @@ class RequestHandler(BaseHTTPRequestHandler):
                     page_ok = True
             else:  # server type request - get or set info
                 start_time = time.time()
+                params = dict(urlparse.parse_qsl(path_split[1], True))
+                if "queue_snapshot" in params:
+                    self.server._send_json(self, self.server._controller.get_queue_snapshot(limit=QUEUE_PREVIEW_LIMIT))
+                    self.connection.close()
+                    return
+                if "queue_jump" in params:
+                    result = self.server._controller.jump_to_queue_index(params.get("queue_jump"))
+                    self.server._send_json(self, result)
+                    self.connection.close()
+                    return
+                if "queue_thumb" in params:
+                    thumb_bytes = self.server._get_queue_thumb_bytes(params.get("queue_thumb"))
+                    self.send_response(200)
+                    self.send_header('Content-type', 'image/jpeg')
+                    self.send_header('Content-Length', str(len(thumb_bytes)))
+                    self.end_headers()
+                    self.wfile.write(thumb_bytes)
+                    self.connection.close()
+                    return
+
                 message = {}
                 self.send_response(200)
                 self.server._logger.debug('http request from: ' + self.client_address[0])
 
-                for key, value in dict(urlparse.parse_qsl(path_split[1], True)).items():
+                for key, value in params.items():
                     self.send_header('Content-type', 'text')
                     self.end_headers()
                     if key == "all":
@@ -320,6 +345,9 @@ class InterfaceHttp(HTTPServer):
         self._setters = [method for method in dir(controller_class)
                          if 'setter' in dir(getattr(controller_class, method))]
         self._jinja_env = Environment(loader=FileSystemLoader(self._html_path))
+        self._thumb_cache = OrderedDict()
+        self._thumb_cache_lock = threading.Lock()
+        self._thumb_placeholder = self._build_placeholder_thumb()
         t = threading.Thread(target=self.serve_forever)
         t.start()
 
@@ -339,6 +367,95 @@ class InterfaceHttp(HTTPServer):
             groups=groups,
             ids_json=json.dumps(ids_js),
         ).encode("utf-8")
+
+    def _send_json(self, handler, payload):
+        body = json.dumps(payload).encode("utf-8")
+        handler.send_response(200)
+        handler.send_header('Content-type', 'application/json')
+        handler.send_header('Content-Length', str(len(body)))
+        handler.end_headers()
+        handler.wfile.write(body)
+
+    def _build_placeholder_thumb(self):
+        image = Image.new("RGB", QUEUE_THUMB_SIZE, color=(28, 28, 30))
+        buf = io.BytesIO()
+        image.save(buf, format="JPEG", quality=60)
+        return buf.getvalue()
+
+    def _read_thumb_cache(self, cache_key):
+        with self._thumb_cache_lock:
+            cached = self._thumb_cache.get(cache_key)
+            if cached is None:
+                return None
+            self._thumb_cache.move_to_end(cache_key)
+            return cached
+
+    def _write_thumb_cache(self, cache_key, thumb_bytes):
+        with self._thumb_cache_lock:
+            self._thumb_cache[cache_key] = thumb_bytes
+            self._thumb_cache.move_to_end(cache_key)
+            while len(self._thumb_cache) > THUMB_CACHE_SIZE:
+                self._thumb_cache.popitem(last=False)
+
+    def _get_queue_thumb_bytes(self, index):
+        source_path = self._controller.get_queue_thumb_source(index)
+        if not source_path:
+            return self._thumb_placeholder
+
+        source_path = urlparse.unquote(source_path)
+        extension = os.path.splitext(source_path)[1].lower()
+        if extension in ('.heic', '.heif'):
+            try:
+                source_mtime = os.path.getmtime(source_path)
+            except OSError:
+                return self._thumb_placeholder
+        elif extension in EXTENSION_TO_MIMETYPE or extension in ('.png',):
+            try:
+                source_mtime = os.path.getmtime(source_path)
+            except OSError:
+                return self._thumb_placeholder
+        else:
+            try:
+                from picframe.video_streamer import VIDEO_EXTENSIONS
+                if extension in VIDEO_EXTENSIONS:
+                    frame_path = os.path.splitext(source_path)[0] + ".1.frame"
+                    source_mtime = os.path.getmtime(frame_path)
+                    source_path = frame_path
+                else:
+                    return self._thumb_placeholder
+            except OSError:
+                return self._thumb_placeholder
+
+        cache_key = (source_path, source_mtime, QUEUE_THUMB_SIZE)
+        cached = self._read_thumb_cache(cache_key)
+        if cached is not None:
+            return cached
+
+        try:
+            if extension in ('.heic', '.heif'):
+                image = heif_to_image(source_path)
+            else:
+                image = Image.open(source_path)
+            if image is None:
+                return self._thumb_placeholder
+
+            image = ImageOps.exif_transpose(image)
+            if image.mode not in ("RGB", "RGBA"):
+                image = image.convert("RGB")
+            elif image.mode == "RGBA":
+                background = Image.new("RGB", image.size, (28, 28, 30))
+                background.paste(image, mask=image.split()[-1])
+                image = background
+            image.thumbnail(QUEUE_THUMB_SIZE, THUMB_RESAMPLE)
+            buf = io.BytesIO()
+            image.save(buf, format="JPEG", quality=72, optimize=True)
+            thumb_bytes = buf.getvalue()
+        except Exception:
+            self._logger.warning("Failed to generate queue thumbnail for %s", source_path, exc_info=True)
+            return self._thumb_placeholder
+
+        self._write_thumb_cache(cache_key, thumb_bytes)
+        return thumb_bytes
 
     def stop(self):
         t = threading.Thread(target=self.shutdown, daemon=True)

--- a/src/picframe/interface_http.py
+++ b/src/picframe/interface_http.py
@@ -36,7 +36,12 @@ EXTENSION_TO_MIMETYPE = {
     # Images
     '.jpg': 'image/jpeg',
     '.jpeg': 'image/jpeg',
-    '.png': 'image/png'
+    '.png': 'image/png',
+
+    # Static UI files
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.css': 'text/css',
 }
 if register_heif_opener is not None:
     EXTENSIONS += [".heif", ".heic"]
@@ -150,7 +155,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                         is_bytes = False
                 else:
                     page = os.path.join(self.server._html_path, html_page)
-                    content_type = "text/html"
+                    content_type = EXTENSION_TO_MIMETYPE.get(extension, "text/html")
                     is_bytes = False
                 page = urlparse.unquote(page)
                 if (not is_bytes and os.path.isfile(page)) or is_bytes:

--- a/src/picframe/interface_http.py
+++ b/src/picframe/interface_http.py
@@ -18,7 +18,7 @@ except ImportError:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer  # py2
     import urlparse
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 try:
     from pi_heif import register_heif_opener
@@ -160,11 +160,23 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.server._logger.warning(log_message)
             return
         try:
-            path_split = self.path.split("?")
+            parsed_url = urlparse.urlsplit(self.path)
+            request_path = parsed_url.path
+            params = dict(urlparse.parse_qsl(parsed_url.query, True))
             page_ok = False
-            if len(path_split) == 1:  # i.e. no ? - just serve index.html or image
-                if path_split[0] != "/":  # serve static page from html_path...
-                    html_page = path_split[0].strip("/")
+            if request_path != "/":  # serve static page from html_path...
+                html_page = request_path.strip("/")
+            else:
+                html_page = "index.html"
+            _, extension = os.path.splitext(html_page)
+            serve_static = (
+                not parsed_url.query
+                or html_page in ("current_image", "current_image_original")
+                or extension in [".html", ".js", ".css"]
+            )
+            if serve_static:
+                if request_path != "/":  # serve static page from html_path...
+                    html_page = request_path.strip("/")
                 else:
                     html_page = "index.html"
                 _, extension = os.path.splitext(html_page)
@@ -237,7 +249,6 @@ class RequestHandler(BaseHTTPRequestHandler):
                     page_ok = True
             else:  # server type request - get or set info
                 start_time = time.time()
-                params = dict(urlparse.parse_qsl(path_split[1], True))
                 if "queue_snapshot" in params:
                     self.server._send_json(self, self.server._controller.get_queue_snapshot(limit=QUEUE_PREVIEW_LIMIT))
                     self.connection.close()
@@ -344,7 +355,10 @@ class InterfaceHttp(HTTPServer):
         controller_class = controller.__class__
         self._setters = [method for method in dir(controller_class)
                          if 'setter' in dir(getattr(controller_class, method))]
-        self._jinja_env = Environment(loader=FileSystemLoader(self._html_path))
+        self._jinja_env = Environment(
+            loader=FileSystemLoader(self._html_path),
+            autoescape=select_autoescape(("html", "xml")),
+        )
         self._thumb_cache = OrderedDict()
         self._thumb_cache_lock = threading.Lock()
         self._thumb_placeholder = self._build_placeholder_thumb()
@@ -365,7 +379,7 @@ class InterfaceHttp(HTTPServer):
             groups.append({**group, "controls": controls})
         return self._jinja_env.get_template("index.html").render(
             groups=groups,
-            ids_json=json.dumps(ids_js),
+            ids=ids_js,
         ).encode("utf-8")
 
     def _send_json(self, handler, payload):

--- a/src/picframe/interface_http.py
+++ b/src/picframe/interface_http.py
@@ -17,6 +17,8 @@ except ImportError:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer  # py2
     import urlparse
 
+from jinja2 import Environment, FileSystemLoader
+
 try:
     from pi_heif import register_heif_opener
 except ImportError:
@@ -86,6 +88,42 @@ def heif_to_image(fname: str) -> Optional[Image.Image]:
         logger = logging.getLogger("interface_http.heif_to_jpg")
         logger.warning("Failed attempt to convert %s due to %s \n** Have you installed pi_heif? **", fname, e)
         return None
+
+CONTROL_GROUPS = [
+    {"key": "nav", "label": "Navigation", "danger": False, "controls": [
+        {"id": "back",   "type": "action", "fn": "back={}",  "val": False},
+        {"id": "next",   "type": "action", "fn": "next={}",  "val": False},
+        {"id": "paused", "type": "bool",   "fn": "setter",   "val": False},
+    ]},
+    {"key": "display", "label": "Display", "danger": False, "controls": [
+        {"id": "display_is_on", "type": "bool",   "fn": "setter", "val": False},
+        {"id": "shuffle",       "type": "bool",   "fn": "setter", "val": False},
+        {"id": "brightness",    "type": "number", "fn": "setter", "val": 0},
+        {"id": "fade_time",     "type": "number", "fn": "setter", "val": 0},
+        {"id": "time_delay",    "type": "number", "fn": "setter", "val": 0},
+    ]},
+    {"key": "text", "label": "Text Overlays", "danger": False, "controls": [
+        {"id": "text_name",         "type": "bool",   "fn": 'set_show_text={"txt_key":"name","val":$val}',     "val": False},
+        {"id": "text_date",         "type": "bool",   "fn": 'set_show_text={"txt_key":"date","val":$val}',     "val": False},
+        {"id": "text_folder",       "type": "bool",   "fn": 'set_show_text={"txt_key":"folder","val":$val}',   "val": False},
+        {"id": "text_location",     "type": "bool",   "fn": 'set_show_text={"txt_key":"location","val":$val}', "val": False},
+        {"id": "clear_text",        "type": "action", "fn": "set_show_text={}",                                 "val": False},
+        {"id": "refresh_show_text", "type": "action", "fn": "refresh_show_text={}",                             "val": False},
+    ]},
+    {"key": "filter", "label": "Filters", "danger": False, "controls": [
+        {"id": "date_from",       "type": "date", "fn": "setter", "val": 0},
+        {"id": "date_to",         "type": "date", "fn": "setter", "val": 0},
+        {"id": "subdirectory",    "type": "text", "fn": "setter", "val": ""},
+        {"id": "location_filter", "type": "text", "fn": "setter", "val": ""},
+        {"id": "tags_filter",     "type": "text", "fn": "setter", "val": ""},
+    ]},
+    {"key": "actions", "label": "Actions", "danger": True, "controls": [
+        {"id": "delete",      "type": "action", "fn": "delete={}",      "val": False},
+        {"id": "purge_files", "type": "action", "fn": "purge_files={}", "val": False},
+        {"id": "stop",        "type": "action", "fn": "stop={}",        "val": False},
+    ]},
+]
+
 
 class RequestHandler(BaseHTTPRequestHandler):
 
@@ -158,7 +196,16 @@ class RequestHandler(BaseHTTPRequestHandler):
                     content_type = EXTENSION_TO_MIMETYPE.get(extension, "text/html")
                     is_bytes = False
                 page = urlparse.unquote(page)
-                if (not is_bytes and os.path.isfile(page)) or is_bytes:
+                if html_page == "index.html":
+                    rendered = self.server._render_index()
+                    self.send_response(200)
+                    self.send_header('Content-type', 'text/html')
+                    self.send_header('Content-Length', str(len(rendered)))
+                    self.end_headers()
+                    self.wfile.write(rendered)
+                    self.connection.close()
+                    page_ok = True
+                elif (not is_bytes and os.path.isfile(page)) or is_bytes:
                     self.send_response(200)
                     self.send_header('Content-type', content_type)
                     file_size = os.path.getsize(page)
@@ -272,8 +319,26 @@ class InterfaceHttp(HTTPServer):
         controller_class = controller.__class__
         self._setters = [method for method in dir(controller_class)
                          if 'setter' in dir(getattr(controller_class, method))]
+        self._jinja_env = Environment(loader=FileSystemLoader(self._html_path))
         t = threading.Thread(target=self.serve_forever)
         t.start()
+
+    def _render_index(self):
+        state = {key: getattr(self._controller, key) for key in self._setters}
+        groups = []
+        ids_js = {}
+        for group in CONTROL_GROUPS:
+            controls = []
+            for ctrl in group["controls"]:
+                c = dict(ctrl)
+                c["val"] = state.get(ctrl["id"], ctrl["val"])
+                controls.append(c)
+                ids_js[ctrl["id"]] = {"type": ctrl["type"], "fn": ctrl["fn"], "val": c["val"]}
+            groups.append({**group, "controls": controls})
+        return self._jinja_env.get_template("index.html").render(
+            groups=groups,
+            ids_json=json.dumps(ids_js),
+        ).encode("utf-8")
 
     def stop(self):
         t = threading.Thread(target=self.shutdown, daemon=True)

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -63,6 +63,10 @@ DEFAULT_CONFIG = {
         'menu_text_sz': 40,
         'menu_autohide_tm': 10.0,
         'geo_suppress_list': [],
+        'show_progress_bar': False,
+        'progress_bar_height': 8,
+        'progress_bar_color': [255, 255, 255, 200],
+        'progress_bar_position': 'B',
     },
     'model': {
 

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -512,7 +512,9 @@ class Model:
             # Sort least-shown photos first, random within equal counts.
             # This ensures unseen photos always appear before already-shown ones,
             # preventing the same photos from dominating when the frame restarts mid-cycle.
-            sort_list.append("displayed_count ASC, RANDOM()")
+            # displayed_count is on the file table (not exposed in the all_data view),
+            # so use a correlated subquery to reach it.
+            sort_list.append("(SELECT f.displayed_count FROM file f WHERE f.file_id = all_data.file_id) ASC, RANDOM()")
         else:
             if self.__col_names is None:
                 self.__col_names = self.__image_cache.get_column_names()  # do this once

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -509,7 +509,10 @@ class Model:
             sort_list.append("last_modified < {:.0f}".format(time.time() - 3600 * 24 * recent_n))
 
         if self.shuffle:
-            sort_list.append("RANDOM()")
+            # Sort least-shown photos first, random within equal counts.
+            # This ensures unseen photos always appear before already-shown ones,
+            # preventing the same photos from dominating when the frame restarts mid-cycle.
+            sort_list.append("displayed_count ASC, RANDOM()")
         else:
             if self.__col_names is None:
                 self.__col_names = self.__image_cache.get_column_names()  # do this once

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -3,6 +3,7 @@ import os
 import time
 import logging
 import locale
+import threading
 from picframe import geo_reverse, image_cache
 
 DEFAULT_CONFIGFILE = "~/picframe_data/config/configuration.yaml"
@@ -205,6 +206,7 @@ class Model:
         self.__file_index = 0  # pointer to next position in __file_list
         self.__current_pics = (None, None)  # this hold a tuple of (pic, None) or two pic objects if portrait pairs
         self.__num_run_through = 0
+        self.__file_list_lock = threading.Lock()
 
         model_config = self.get_model_config()  # alias for brevity as used several times below
         try:
@@ -395,7 +397,104 @@ class Model:
         self.__reload_files = True
 
     def set_next_file_to_previous_file(self):
-        self.__file_index = (self.__file_index - 2) % self.__number_of_files  # TODO deleting last image results in ZeroDivisionError # noqa: E501
+        with self.__file_list_lock:
+            self.__file_index = (self.__file_index - 2) % self.__number_of_files  # TODO deleting last image results in ZeroDivisionError # noqa: E501
+
+    def set_next_file_index(self, index):
+        with self.__file_list_lock:
+            if self.__reload_files:
+                return False, "reload_pending"
+            if self.__number_of_files == 0:
+                return False, "empty_queue"
+            try:
+                index = int(index)
+            except (TypeError, ValueError):
+                return False, "invalid_index"
+            if index < 0 or index >= self.__number_of_files:
+                return False, "invalid_index"
+            self.__file_index = index
+        return True, "ok"
+
+    def get_queue_snapshot(self, limit=8):
+        try:
+            limit = max(0, int(limit))
+        except (TypeError, ValueError):
+            limit = 8
+
+        with self.__file_list_lock:
+            queue_slots = list(self.__file_list)
+            next_index = self.__file_index
+            reload_pending = self.__reload_files
+            total_slots = self.__number_of_files
+            current_pics = self.__current_pics
+
+        displayed_index = None
+        if total_slots > 0 and current_pics[0] is not None:
+            displayed_index = (next_index - 1) % total_slots
+
+        upcoming_slots = []
+        if total_slots > 0:
+            for offset in range(min(limit, total_slots)):
+                slot_index = (next_index + offset) % total_slots
+                upcoming_slots.append(self.__build_queue_slot(slot_index, queue_slots[slot_index]))
+
+        current_slot = None
+        if displayed_index is not None:
+            current_slot = self.__build_queue_slot(displayed_index, queue_slots[displayed_index])
+
+        return {
+            "reload_pending": reload_pending,
+            "displayed_index": displayed_index,
+            "next_index": next_index if total_slots > 0 else None,
+            "total_slots": total_slots,
+            "current_slot": current_slot,
+            "upcoming_slots": upcoming_slots,
+        }
+
+    def get_queue_thumb_source(self, index):
+        with self.__file_list_lock:
+            if self.__number_of_files == 0:
+                return None
+            try:
+                index = int(index)
+            except (TypeError, ValueError):
+                return None
+            if index < 0 or index >= self.__number_of_files:
+                return None
+            file_ids = self.__file_list[index]
+        slot = self.__build_queue_slot(index, file_ids)
+        return slot["primary_path"] if slot is not None else None
+
+    def __build_queue_slot(self, slot_index, file_ids):
+        file_infos = []
+        for file_id in file_ids:
+            row = self.__image_cache.get_file_info_readonly(file_id)
+            if row is None:
+                continue
+            file_infos.append(dict(row))
+
+        if not file_infos:
+            return {
+                "slot_index": slot_index,
+                "file_ids": list(file_ids),
+                "is_pair": len(file_ids) == 2,
+                "primary_label": "Unavailable",
+                "secondary_label": None,
+                "primary_path": None,
+                "thumb_version": 0,
+            }
+
+        primary = file_infos[0]
+        secondary = file_infos[1] if len(file_infos) > 1 else None
+        return {
+            "slot_index": slot_index,
+            "file_ids": list(file_ids),
+            "is_pair": len(file_ids) == 2,
+            "primary_label": os.path.basename(primary["fname"]),
+            "secondary_label": os.path.basename(secondary["fname"]) if secondary is not None else None,
+            "primary_path": primary["fname"],
+            "thumb_version": int(primary.get("last_modified") or 0),
+        }
 
     def get_next_file(self):
         missing_images = 0
@@ -416,7 +515,9 @@ class Model:
 
             # If we don't have any files to show, prepare the "no images" image
             # Also, set the reload_files flag so we'll check for new files on the next pass...
-            if self.__number_of_files == 0 or missing_images >= self.__number_of_files:
+            with self.__file_list_lock:
+                number_of_files = self.__number_of_files
+            if number_of_files == 0 or missing_images >= number_of_files:
                 pic1 = Pic(self.__no_files_img, 0, 0)
                 self.__reload_files = True
                 break
@@ -424,15 +525,21 @@ class Model:
             # If we've displayed all images...
             #   If it's time to shuffle, set a flag to do so
             #   Loop back, which will reload and shuffle if necessary
-            if self.__file_index == self.__number_of_files:
-                self.__num_run_through += 1
-                if self.shuffle and self.__num_run_through >= self.get_model_config()['reshuffle_num']:
-                    self.__reload_files = True
-                self.__file_index = 0
+            wrapped = False
+            with self.__file_list_lock:
+                if self.__file_index == self.__number_of_files:
+                    self.__num_run_through += 1
+                    if self.shuffle and self.__num_run_through >= self.get_model_config()['reshuffle_num']:
+                        self.__reload_files = True
+                    self.__file_index = 0
+                    wrapped = True
+            if wrapped:
                 continue
 
             # Load the current image set
-            file_ids = self.__file_list[self.__file_index]
+            with self.__file_list_lock:
+                file_ids = self.__file_list[self.__file_index]
+                self.__file_index += 1
             pic_row = self.__image_cache.get_file_info(file_ids[0])
             pic1 = Pic(**pic_row) if pic_row is not None else None
             if len(file_ids) == 2:
@@ -449,9 +556,6 @@ class Model:
             if (not pic1 and pic2):
                 pic1, pic2 = pic2, pic1
 
-            # Increment the image index for next time
-            self.__file_index += 1
-
             # If pic1 is valid here, everything is OK. Break out of the loop and return the set
             if pic1:
                 break
@@ -460,17 +564,21 @@ class Model:
             # Track the number of times we've looped back so we can abort if we don't have *any* images to display
             missing_images += 1
 
-        self.__current_pics = (pic1, pic2)
+        with self.__file_list_lock:
+            self.__current_pics = (pic1, pic2)
         return self.__current_pics
 
     def get_number_of_files(self):
+        with self.__file_list_lock:
+            file_list = list(self.__file_list)
         return sum(
                     sum(1 for pic in pics if pic is not None)
-                    for pics in self.__file_list
+                    for pics in file_list
                 )
 
     def get_current_pics(self):
-        return self.__current_pics
+        with self.__file_list_lock:
+            return self.__current_pics
 
     def delete_file(self):
         # delete the current pic. If it's a portrait pair then only the left one will be deleted
@@ -485,11 +593,12 @@ class Model:
             os.system("mkdir {}".format(move_to_dir))  # problems with ownership using python func
         os.system("mv '{}' '{}'".format(f_to_delete, move_to_dir))  # and with SMB drives
         # find and delete record from __file_list
-        for i, file_rec in enumerate(self.__file_list):
-            if file_rec[0] == pic.file_id:  # database id TODO check that db tidies itself up
-                self.__file_list.pop(i)
-                self.__number_of_files -= 1
-                break
+        with self.__file_list_lock:
+            for i, file_rec in enumerate(self.__file_list):
+                if file_rec[0] == pic.file_id:  # database id TODO check that db tidies itself up
+                    self.__file_list.pop(i)
+                    self.__number_of_files -= 1
+                    break
 
     def __get_files(self):
         if self.subdirectory != "":
@@ -510,7 +619,7 @@ class Model:
             recent_cutoff = time.time() - 3600 * 24 * recent_n
 
         if self.shuffle:
-            self.__file_list = self.__image_cache.query_cache_shuffle(where_clause, recent_cutoff=recent_cutoff)
+            file_list = self.__image_cache.query_cache_shuffle(where_clause, recent_cutoff=recent_cutoff)
         else:
             sort_list = []
             if recent_cutoff is not None:
@@ -523,11 +632,13 @@ class Model:
                     sort_list.append(col)
             sort_list.append("fname ASC")  # always finally sort on this in case nothing else to sort on or sort_cols is "" # noqa: E501
             sort_clause = ",".join(sort_list)
-            self.__file_list = self.__image_cache.query_cache(where_clause, sort_clause)
-        self.__number_of_files = len(self.__file_list)
-        self.__file_index = 0
-        self.__num_run_through = 0
-        self.__reload_files = False
+            file_list = self.__image_cache.query_cache(where_clause, sort_clause)
+        with self.__file_list_lock:
+            self.__file_list = file_list
+            self.__number_of_files = len(self.__file_list)
+            self.__file_index = 0
+            self.__num_run_through = 0
+            self.__reload_files = False
 
     def __generate_random_string(self, length):
         random_bytes = os.urandom(length // 2)

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -142,7 +142,7 @@ class Pic:  # TODO could this be done more elegantly with namedtuple
                  f_number=0, exposure_time=None, iso=0, focal_length=None,
                  make=None, model=None, lens=None, rating=None, latitude=None,
                  longitude=None, width=0, height=0, is_portrait=0, location=None, title=None,
-                 caption=None, tags=None):
+                 caption=None, tags=None, displayed_count=0):
         self.fname = fname
         self.last_modified = last_modified
         self.file_id = file_id
@@ -165,6 +165,7 @@ class Pic:  # TODO could this be done more elegantly with namedtuple
         self.tags = tags
         self.caption = caption
         self.title = title
+        self.displayed_count = displayed_count
 
 
 class Model:
@@ -512,9 +513,7 @@ class Model:
             # Sort least-shown photos first, random within equal counts.
             # This ensures unseen photos always appear before already-shown ones,
             # preventing the same photos from dominating when the frame restarts mid-cycle.
-            # displayed_count is on the file table (not exposed in the all_data view),
-            # so use a correlated subquery to reach it.
-            sort_list.append("(SELECT f.displayed_count FROM file f WHERE f.file_id = all_data.file_id) ASC, RANDOM()")
+            sort_list.append("displayed_count ASC, RANDOM()")
         else:
             if self.__col_names is None:
                 self.__col_names = self.__image_cache.get_column_names()  # do this once

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -504,17 +504,17 @@ class Model:
         else:
             where_clause = "1"
 
-        sort_list = []
         recent_n = self.get_model_config()["recent_n"]
+        recent_cutoff = None
         if recent_n > 0:
-            sort_list.append("last_modified < {:.0f}".format(time.time() - 3600 * 24 * recent_n))
+            recent_cutoff = time.time() - 3600 * 24 * recent_n
 
         if self.shuffle:
-            # Sort least-shown photos first, random within equal counts.
-            # This ensures unseen photos always appear before already-shown ones,
-            # preventing the same photos from dominating when the frame restarts mid-cycle.
-            sort_list.append("displayed_count ASC, RANDOM()")
+            self.__file_list = self.__image_cache.query_cache_shuffle(where_clause, recent_cutoff=recent_cutoff)
         else:
+            sort_list = []
+            if recent_cutoff is not None:
+                sort_list.append("last_modified < {:.0f}".format(recent_cutoff))
             if self.__col_names is None:
                 self.__col_names = self.__image_cache.get_column_names()  # do this once
             for col in self.__sort_cols.split(","):
@@ -522,9 +522,8 @@ class Model:
                 if colsplit[0] in self.__col_names and (len(colsplit) == 1 or colsplit[1].upper() in ("ASC", "DESC")):
                     sort_list.append(col)
             sort_list.append("fname ASC")  # always finally sort on this in case nothing else to sort on or sort_cols is "" # noqa: E501
-        sort_clause = ",".join(sort_list)
-
-        self.__file_list = self.__image_cache.query_cache(where_clause, sort_clause)
+            sort_clause = ",".join(sort_list)
+            self.__file_list = self.__image_cache.query_cache(where_clause, sort_clause)
         self.__number_of_files = len(self.__file_list)
         self.__file_index = 0
         self.__num_run_through = 0

--- a/src/picframe/viewer_display.py
+++ b/src/picframe/viewer_display.py
@@ -110,6 +110,8 @@ class ViewerDisplay:
         self.__image_overlay = None
         self.__prev_overlay_time = None
         self.__video_streamer = None
+        self.__paused = False
+        self.__pause_start_tm = None
 
         # [ivan] sensors configs
         self.__show_sensors = config['show_sensors']
@@ -561,7 +563,7 @@ class ViewerDisplay:
     def __draw_progress_bar(self, time_delay):
         if self.__next_tm == 0.0:
             return
-        tm = time.time()
+        tm = self.__pause_start_tm if self.__paused and self.__pause_start_tm is not None else time.time()
         progress = max(0.0, min(1.0, 1.0 - (self.__next_tm - tm) / time_delay)) if time_delay > 0 else 0.0
         bar_w = max(1, int(self.__display.width * progress))
 
@@ -573,6 +575,23 @@ class ViewerDisplay:
 
         if self.__progress_bar_fill:
             self.__progress_bar_fill.draw()
+
+    def __sync_pause_state(self, paused):
+        tm = time.time()
+        if paused != self.__paused:
+            self.__paused = paused
+            if paused:
+                self.__pause_start_tm = tm
+            elif self.__pause_start_tm is not None:
+                paused_for = tm - self.__pause_start_tm
+                if self.__next_tm > 0.0:
+                    self.__next_tm += paused_for
+                if self.__name_tm > 0.0:
+                    self.__name_tm += paused_for
+                self.__pause_start_tm = None
+        elif paused and self.__pause_start_tm is not None:
+            return self.__pause_start_tm
+        return tm
 
     # Draws the temperature and humidity info
     def __draw_sensors(self):
@@ -840,7 +859,7 @@ class ViewerDisplay:
             self.__slide.draw()
             return (loop_running, False, video_playing)  # now returns tuple with skip image flag and video_time added
 
-        tm = time.time()
+        tm = self.__sync_pause_state(paused)
         if pics is not None:
             self.stop_video()
             if pics[0] and os.path.splitext(pics[0].fname)[1].lower() in VIDEO_EXTENSIONS:
@@ -899,7 +918,7 @@ class ViewerDisplay:
             self.__slide.unif[48] = self.__slide.unif[48] * 0.95 + self.__xstep * t_factor * 0.05
             self.__slide.unif[49] = self.__slide.unif[49] * 0.95 + self.__ystep * t_factor * 0.05
 
-        if self.__alpha < 1.0:  # transition is happening
+        if self.__alpha < 1.0 and not paused:  # transition is happening
             self.__alpha += self.__delta_alpha
             if self.__alpha > 1.0:
                 self.__alpha = 1.0

--- a/src/picframe/viewer_display.py
+++ b/src/picframe/viewer_display.py
@@ -566,10 +566,10 @@ class ViewerDisplay:
             self.__progress_bar_fill = self.__make_solid_bar()
 
         # Update scale and position via transform only — no geometry/VBO rebuild, perfectly smooth
+        # unif[6] is the x-scale uniform (pi3d Sprite passes w= as sx to Shape.__init__)
         W = self.__display.width
-        self.__progress_bar_fill.scl[0] = progress
-        self.__progress_bar_fill.MFlg = True
-        self.__progress_bar_fill.positionX(-W * (1.0 - progress) / 2.0)
+        self.__progress_bar_fill.unif[6] = W * progress
+        self.__progress_bar_fill.positionX(-W * (1.0 - progress) / 2.0)  # pin left edge to screen left
         self.__progress_bar_fill.draw()
 
     # Draws the temperature and humidity info

--- a/src/picframe/viewer_display.py
+++ b/src/picframe/viewer_display.py
@@ -139,6 +139,7 @@ class ViewerDisplay:
         self.__progress_bar_position = config['progress_bar_position']
         self.__progress_bar_tex = None
         self.__progress_bar_fill = None
+        self.__prev_bar_w = -1
 
         ImageFile.LOAD_TRUNCATED_IMAGES = True  # occasional damaged file hangs app
 
@@ -540,18 +541,17 @@ class ViewerDisplay:
             self.__image_overlay.draw()
 
 
-    # [ivan] Creates a solid-color sprite for the progress bar (created once at full display width)
-    def __make_solid_bar(self):
+    # [ivan] Creates a solid-color sprite for the progress bar
+    def __make_solid_bar(self, w, h, x):
         if self.__progress_bar_tex is None:
             r, g, b, a = self.__progress_bar_color
             tex_arr = np.zeros((1, 1, 4), dtype=np.uint8)
             tex_arr[0, 0] = [r, g, b, a]
             self.__progress_bar_tex = pi3d.Texture(tex_arr, blend=True, mipmap=False, free_after_load=True)
-        h = self.__progress_bar_height
         bar_y = (self.__display.height - h) // 2
         if self.__progress_bar_position == "B":
             bar_y *= -1
-        sprite = pi3d.Sprite(w=self.__display.width, h=h, x=0, y=bar_y, z=3.9)
+        sprite = pi3d.Sprite(w=w, h=h, x=x, y=bar_y, z=3.9)
         sprite.set_draw_details(self.__flat_shader, [self.__progress_bar_tex])
         return sprite
 
@@ -560,17 +560,17 @@ class ViewerDisplay:
         if self.__next_tm == 0.0:
             return
         tm = time.time()
-        progress = max(0.001, min(1.0, 1.0 - (self.__next_tm - tm) / time_delay)) if time_delay > 0 else 0.001
+        progress = max(0.0, min(1.0, 1.0 - (self.__next_tm - tm) / time_delay)) if time_delay > 0 else 0.0
+        bar_w = max(1, int(self.__display.width * progress))
 
-        if self.__progress_bar_fill is None:
-            self.__progress_bar_fill = self.__make_solid_bar()
+        if bar_w != self.__prev_bar_w:
+            x = bar_w // 2 - self.__display.width // 2
+            self.__progress_bar_fill = self.__make_solid_bar(
+                w=bar_w, h=self.__progress_bar_height, x=x)
+            self.__prev_bar_w = bar_w
 
-        # Update scale and position via transform only — no geometry/VBO rebuild, perfectly smooth
-        # unif[6] is the x-scale uniform (pi3d Sprite passes w= as sx to Shape.__init__)
-        W = self.__display.width
-        self.__progress_bar_fill.unif[6] = W * progress
-        self.__progress_bar_fill.positionX(-W * (1.0 - progress) / 2.0)  # pin left edge to screen left
-        self.__progress_bar_fill.draw()
+        if self.__progress_bar_fill:
+            self.__progress_bar_fill.draw()
 
     # Draws the temperature and humidity info
     def __draw_sensors(self):

--- a/src/picframe/viewer_display.py
+++ b/src/picframe/viewer_display.py
@@ -449,6 +449,8 @@ class ViewerDisplay:
             if paused:
                 info_strings.append("PAUSED")
         final_string = " • ".join(info_strings)
+        if final_string:
+            final_string = "[{}] {}".format(pic.displayed_count, final_string)
 
         block = None
         if len(final_string) > 0:

--- a/src/picframe/viewer_display.py
+++ b/src/picframe/viewer_display.py
@@ -139,7 +139,6 @@ class ViewerDisplay:
         self.__progress_bar_position = config['progress_bar_position']
         self.__progress_bar_tex = None
         self.__progress_bar_fill = None
-        self.__prev_progress = -1.0
 
         ImageFile.LOAD_TRUNCATED_IMAGES = True  # occasional damaged file hangs app
 
@@ -541,17 +540,18 @@ class ViewerDisplay:
             self.__image_overlay.draw()
 
 
-    # [ivan] Creates a solid-color sprite for the progress bar
-    def __make_solid_bar(self, w, h, x):
+    # [ivan] Creates a solid-color sprite for the progress bar (created once at full display width)
+    def __make_solid_bar(self):
         if self.__progress_bar_tex is None:
             r, g, b, a = self.__progress_bar_color
             tex_arr = np.zeros((1, 1, 4), dtype=np.uint8)
             tex_arr[0, 0] = [r, g, b, a]
             self.__progress_bar_tex = pi3d.Texture(tex_arr, blend=True, mipmap=False, free_after_load=True)
+        h = self.__progress_bar_height
         bar_y = (self.__display.height - h) // 2
         if self.__progress_bar_position == "B":
             bar_y *= -1
-        sprite = pi3d.Sprite(w=w, h=h, x=x, y=bar_y, z=3.9)
+        sprite = pi3d.Sprite(w=self.__display.width, h=h, x=0, y=bar_y, z=3.9)
         sprite.set_draw_details(self.__flat_shader, [self.__progress_bar_tex])
         return sprite
 
@@ -560,18 +560,17 @@ class ViewerDisplay:
         if self.__next_tm == 0.0:
             return
         tm = time.time()
-        progress = max(0.0, min(1.0, 1.0 - (self.__next_tm - tm) / time_delay)) if time_delay > 0 else 0.0
-        quantized = round(progress * 200) / 200.0  # 0.5% steps to avoid VBO rebuild every frame
+        progress = max(0.001, min(1.0, 1.0 - (self.__next_tm - tm) / time_delay)) if time_delay > 0 else 0.001
 
-        if quantized != self.__prev_progress:
-            bar_w = max(1, int(self.__display.width * quantized))
-            x = bar_w // 2 - self.__display.width // 2
-            self.__progress_bar_fill = self.__make_solid_bar(
-                w=bar_w, h=self.__progress_bar_height, x=x)
-            self.__prev_progress = quantized
+        if self.__progress_bar_fill is None:
+            self.__progress_bar_fill = self.__make_solid_bar()
 
-        if self.__progress_bar_fill:
-            self.__progress_bar_fill.draw()
+        # Update scale and position via transform only — no geometry/VBO rebuild, perfectly smooth
+        W = self.__display.width
+        self.__progress_bar_fill.scl[0] = progress
+        self.__progress_bar_fill.MFlg = True
+        self.__progress_bar_fill.positionX(-W * (1.0 - progress) / 2.0)
+        self.__progress_bar_fill.draw()
 
     # Draws the temperature and humidity info
     def __draw_sensors(self):

--- a/src/picframe/viewer_display.py
+++ b/src/picframe/viewer_display.py
@@ -132,6 +132,15 @@ class ViewerDisplay:
         else:
             self.__sensors_data = None
 
+        # [ivan] progress bar configs
+        self.__show_progress_bar = config['show_progress_bar']
+        self.__progress_bar_height = config['progress_bar_height']
+        self.__progress_bar_color = config['progress_bar_color']
+        self.__progress_bar_position = config['progress_bar_position']
+        self.__progress_bar_tex = None
+        self.__progress_bar_fill = None
+        self.__prev_progress = -1.0
+
         ImageFile.LOAD_TRUNCATED_IMAGES = True  # occasional damaged file hangs app
 
     def get_sensors_data(self):
@@ -532,6 +541,38 @@ class ViewerDisplay:
             self.__image_overlay.draw()
 
 
+    # [ivan] Creates a solid-color sprite for the progress bar
+    def __make_solid_bar(self, w, h, x):
+        if self.__progress_bar_tex is None:
+            r, g, b, a = self.__progress_bar_color
+            tex_arr = np.zeros((1, 1, 4), dtype=np.uint8)
+            tex_arr[0, 0] = [r, g, b, a]
+            self.__progress_bar_tex = pi3d.Texture(tex_arr, blend=True, mipmap=False, free_after_load=True)
+        bar_y = (self.__display.height - h) // 2
+        if self.__progress_bar_position == "B":
+            bar_y *= -1
+        sprite = pi3d.Sprite(w=w, h=h, x=x, y=bar_y, z=3.9)
+        sprite.set_draw_details(self.__flat_shader, [self.__progress_bar_tex])
+        return sprite
+
+    # [ivan] Draws the progress bar showing time remaining for current photo
+    def __draw_progress_bar(self, time_delay):
+        if self.__next_tm == 0.0:
+            return
+        tm = time.time()
+        progress = max(0.0, min(1.0, 1.0 - (self.__next_tm - tm) / time_delay)) if time_delay > 0 else 0.0
+        quantized = round(progress * 200) / 200.0  # 0.5% steps to avoid VBO rebuild every frame
+
+        if quantized != self.__prev_progress:
+            bar_w = max(1, int(self.__display.width * quantized))
+            x = bar_w // 2 - self.__display.width // 2
+            self.__progress_bar_fill = self.__make_solid_bar(
+                w=bar_w, h=self.__progress_bar_height, x=x)
+            self.__prev_progress = quantized
+
+        if self.__progress_bar_fill:
+            self.__progress_bar_fill.draw()
+
     # Draws the temperature and humidity info
     def __draw_sensors(self):
 
@@ -883,6 +924,8 @@ class ViewerDisplay:
 
         self.__slide.draw()
         self.__draw_overlay()
+        if self.__show_progress_bar:
+            self.__draw_progress_bar(time_delay)
         if self.clock_is_on:
             self.__draw_clock()
 

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -116,6 +116,7 @@ def test_publish_state(mock_mqtt_client, mock_controller, mqtt_config):
     mock_controller.fade_time = 2  # Set a real value
     mock_controller.brightness = 0.8
     mock_controller.matting_images = 0.5
+    mock_controller.get_sensors_data.return_value = None
 
     # Call publish_state
     mqtt_interface.publish_state(image="test_image.jpg", image_attr={"attr1": "value1"})

--- a/test/test_queue_panel.py
+++ b/test/test_queue_panel.py
@@ -1,0 +1,101 @@
+import threading
+
+from picframe.controller import Controller
+from picframe.model import Model
+
+
+class _ImageCacheStub:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_file_info_readonly(self, file_id):
+        return self._rows[file_id]
+
+
+class _ModelStub:
+    def __init__(self, result):
+        self.result = result
+        self.jump_calls = []
+
+    def get_queue_snapshot(self, limit=8):
+        return {"limit": limit, **self.result}
+
+    def get_queue_thumb_source(self, index):
+        return f"/tmp/{index}.jpg"
+
+    def set_next_file_index(self, index):
+        self.jump_calls.append(index)
+        return True, "ok"
+
+
+class _ViewerStub:
+    def __init__(self, playing=False):
+        self.playing = playing
+        self.reset_calls = 0
+        self.stop_calls = 0
+
+    def is_video_playing(self):
+        return self.playing
+
+    def stop_video(self):
+        self.stop_calls += 1
+
+    def reset_name_tm(self, *args, **kwargs):
+        self.reset_calls += 1
+
+
+def _make_model(file_list, rows, file_index, reload_pending=False, has_current=True):
+    model = Model.__new__(Model)
+    model._Model__file_list = file_list
+    model._Model__number_of_files = len(file_list)
+    model._Model__file_index = file_index
+    model._Model__reload_files = reload_pending
+    model._Model__current_pics = (object(), None) if has_current else (None, None)
+    model._Model__file_list_lock = threading.Lock()
+    model._Model__image_cache = _ImageCacheStub(rows)
+    return model
+
+
+def test_queue_snapshot_uses_slot_count_and_pair_labels():
+    rows = {
+        1: {"fname": "/photos/one.jpg", "last_modified": 11},
+        2: {"fname": "/photos/two.jpg", "last_modified": 22},
+        3: {"fname": "/photos/three.jpg", "last_modified": 33},
+    }
+    model = _make_model([(1,), (2, 3)], rows, file_index=1)
+
+    snapshot = model.get_queue_snapshot(limit=4)
+
+    assert snapshot["total_slots"] == 2
+    assert snapshot["displayed_index"] == 0
+    assert snapshot["next_index"] == 1
+    assert snapshot["current_slot"]["primary_label"] == "one.jpg"
+    assert snapshot["upcoming_slots"][0]["is_pair"] is True
+    assert snapshot["upcoming_slots"][0]["secondary_label"] == "three.jpg"
+
+
+def test_set_next_file_index_rejects_pending_reload():
+    model = _make_model([(1,), (2,)], {1: {"fname": "/photos/one.jpg", "last_modified": 11},
+                                       2: {"fname": "/photos/two.jpg", "last_modified": 22}},
+                        file_index=1, reload_pending=True)
+
+    success, reason = model.set_next_file_index(0)
+
+    assert success is False
+    assert reason == "reload_pending"
+
+
+def test_controller_jump_forces_immediate_navigation():
+    controller = Controller.__new__(Controller)
+    controller._Controller__model = _ModelStub({"ok": True})
+    controller._Controller__viewer = _ViewerStub(playing=False)
+    controller._Controller__next_tm = 15
+    controller._Controller__force_navigate = False
+
+    result = controller.jump_to_queue_index("4")
+
+    assert result == {"ok": True, "reason": "ok"}
+    assert controller._Controller__model.jump_calls == ["4"]
+    assert controller._Controller__next_tm == 0
+    assert controller._Controller__force_navigate is True
+    assert controller._Controller__viewer.reset_calls == 1

--- a/test/test_weighted_shuffle.py
+++ b/test/test_weighted_shuffle.py
@@ -1,0 +1,122 @@
+import random
+
+from picframe import image_cache
+from picframe.image_cache import ImageCache, weighted_shuffle_rows
+
+
+class _DummyCursor:
+    def __init__(self, rows):
+        self._rows = rows
+        self.row_factory = None
+
+    def execute(self, _sql):
+        return self
+
+    def fetchall(self):
+        return self._rows
+
+
+class _DummyDb:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self):
+        return _DummyCursor(self._rows)
+
+
+def _make_cache(rows, portrait_pairs):
+    cache = ImageCache.__new__(ImageCache)
+    cache._ImageCache__db = _DummyDb(rows)
+    cache._ImageCache__portrait_pairs = portrait_pairs
+    return cache
+
+
+def test_weighted_shuffle_prefers_lower_display_count():
+    rows = [
+        {"file_id": 1, "displayed_count": 0, "last_modified": 100.0, "is_portrait": 0},
+        {"file_id": 2, "displayed_count": 5, "last_modified": 100.0, "is_portrait": 0},
+    ]
+
+    total_position = {1: 0, 2: 0}
+    for seed in range(300):
+        random.seed(seed)
+        ordered_ids = [row["file_id"] for row in weighted_shuffle_rows(rows)]
+        for idx, file_id in enumerate(ordered_ids):
+            total_position[file_id] += idx
+
+    assert total_position[1] < total_position[2]
+
+
+def test_weighted_shuffle_prefers_older_photos_when_counts_match():
+    rows = [
+        {"file_id": 1, "displayed_count": 0, "last_modified": 10.0, "is_portrait": 0},
+        {"file_id": 2, "displayed_count": 0, "last_modified": 100.0, "is_portrait": 0},
+    ]
+
+    total_position = {1: 0, 2: 0}
+    for seed in range(300):
+        random.seed(seed)
+        ordered_ids = [row["file_id"] for row in weighted_shuffle_rows(rows)]
+        for idx, file_id in enumerate(ordered_ids):
+            total_position[file_id] += idx
+
+    assert total_position[1] < total_position[2]
+
+
+def test_weighted_shuffle_keeps_recent_partition_first():
+    rows = [
+        {"file_id": 1, "displayed_count": 5, "last_modified": 10.0, "is_portrait": 0},
+        {"file_id": 2, "displayed_count": 0, "last_modified": 20.0, "is_portrait": 0},
+        {"file_id": 3, "displayed_count": 5, "last_modified": 90.0, "is_portrait": 0},
+        {"file_id": 4, "displayed_count": 0, "last_modified": 100.0, "is_portrait": 0},
+    ]
+
+    random.seed(1)
+    ordered_ids = [row["file_id"] for row in weighted_shuffle_rows(rows, recent_cutoff=50.0)]
+
+    assert set(ordered_ids[:2]) == {3, 4}
+    assert set(ordered_ids[2:]) == {1, 2}
+
+
+def test_query_cache_shuffle_returns_single_tuples_without_portrait_pairs(monkeypatch):
+    rows = [
+        {"file_id": 1, "displayed_count": 0, "last_modified": 10.0, "is_portrait": 0},
+        {"file_id": 2, "displayed_count": 2, "last_modified": 20.0, "is_portrait": 0},
+        {"file_id": 3, "displayed_count": 1, "last_modified": 30.0, "is_portrait": 0},
+    ]
+
+    monkeypatch.setattr(image_cache, "weighted_shuffle_rows", lambda payload_rows, recent_cutoff=None: list(payload_rows))
+    cache = _make_cache(rows, portrait_pairs=False)
+
+    playlist = cache.query_cache_shuffle("1=1")
+
+    assert playlist == [(1,), (2,), (3,)]
+
+
+def test_query_cache_shuffle_pairs_portraits_in_global_order(monkeypatch):
+    rows = [
+        {"file_id": 11, "displayed_count": 0, "last_modified": 1.0, "is_portrait": 1},
+        {"file_id": 12, "displayed_count": 0, "last_modified": 2.0, "is_portrait": 0},
+        {"file_id": 13, "displayed_count": 0, "last_modified": 3.0, "is_portrait": 1},
+        {"file_id": 14, "displayed_count": 0, "last_modified": 4.0, "is_portrait": 1},
+        {"file_id": 15, "displayed_count": 0, "last_modified": 5.0, "is_portrait": 0},
+        {"file_id": 16, "displayed_count": 0, "last_modified": 6.0, "is_portrait": 1},
+    ]
+
+    monkeypatch.setattr(image_cache, "weighted_shuffle_rows", lambda payload_rows, recent_cutoff=None: list(payload_rows))
+    cache = _make_cache(rows, portrait_pairs=True)
+
+    playlist = cache.query_cache_shuffle("1=1")
+
+    expected_playlist = [(11, 13), (12,), (14, 16), (15,)]
+    assert playlist == expected_playlist
+
+    portrait_ids = [entry for entry in rows if entry["is_portrait"] == 1]
+    portrait_sequence = [row["file_id"] for row in portrait_ids]
+    portrait_ids_from_playlist = [
+        file_id
+        for slot in playlist
+        for file_id in slot
+        if file_id in portrait_sequence
+    ]
+    assert portrait_ids_from_playlist == portrait_sequence


### PR DESCRIPTION
## Summary

Adds several photo-frame usability improvements:

- configurable on-screen photo progress bar
- redesigned mobile-friendly web UI with server-rendered controls
- current image preview and upcoming queue panel
- queue jump support from the web UI
- weighted shuffle ordering that favors less-shown photos
- display-count tracking exposed in overlays and MQTT as `times_shown`
- queue and shuffle regression tests
- helper script for checking database files by date range

## Configuration

New viewer options:

- `show_progress_bar`
- `progress_bar_height`
- `progress_bar_color`
- `progress_bar_position`

## Fixes Included

- Allows cache-busted current-image URLs like `/current_image?t=...` to keep serving image content.
- Uses Jinja `tojson` and autoescaping for safely injecting initial control state into the web UI.

## Notes

This also adds `jinja2` as a runtime dependency for rendering the web UI.

## Testing

- Added tests for weighted shuffle behavior.
- Added tests for queue snapshot and queue jump behavior.
- Verified Python syntax with `python3 -m py_compile` for the changed server files.